### PR TITLE
Build specialist agent on Claude Agent SDK (TypeScript)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules/
+dist/
+*.log
+.env
+.env.local
+
+# Per-tenant runtime workspaces (each is its own git repo)
+tenants/
+
+# Build artifacts
+*.tsbuildinfo
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ setDefaultBroker(
 const agent = new SpecialistAgent({
   tenant: { id: "acme", workspacePath: "/var/lib/specialist/tenants/acme" },
   confirmInstructedChange: async (summary) => myUI.confirm(summary),
+  // Spec's "Is `\"USD\"` a wrapper input or a constant?" pass — fires once
+  // per parameter on every newly synthesized wrapper. Default keeps all.
+  confirmParameter: async ({ wrapper, parameter, observedValue }) =>
+    myUI.askParameter({ wrapper, parameter, observedValue }),
 });
 
 for await (const msg of agent.run("Bill alice@example.com $500 for April")) {
@@ -134,13 +138,44 @@ Auth headers and obvious credential keys are scrubbed at capture time (`src/capt
 
 The agent's runtime exposes three tools via the `specialist-meta` MCP server:
 
-| Tool             | Trigger                                       | Confirmation         | Validation                    |
-| ---------------- | --------------------------------------------- | -------------------- | ----------------------------- |
-| `reactive_fix`   | Wrapper call failed with persistent drift     | Auto                 | Replay; merge only on success |
-| `update_wrapper` | User instruction mid-task                     | Required (host hook) | Replay; merge only on success |
-| `add_workflow`   | User walks through a sequence in conversation | Required (host hook) | None (pure prose)             |
+| Tool             | Trigger                                       | Confirmation         | Validation                    | Auto-rollback                      |
+| ---------------- | --------------------------------------------- | -------------------- | ----------------------------- | ---------------------------------- |
+| `reactive_fix`   | Wrapper call failed with persistent drift     | Auto                 | Replay; merge only on success | Yes (revert on first-call failure) |
+| `update_wrapper` | User instruction mid-task                     | Required (host hook) | Replay; merge only on success | Yes (revert on first-call failure) |
+| `add_workflow`   | User walks through a sequence in conversation | Required (host hook) | None (pure prose)             | N/A (no wrappers)                  |
 
 Failed validations stay on a branch (`synth/...`, `meta/...`) so the host can review.
+
+**Auto-rollback** (spec: "if a freshly-merged skill version fails on its first production invocation, the agent reverts the commit"). After a meta-tool merge, the affected wrapper is marked unproven in `tenants/<id>/.specialist-state.json`. A `PostToolUse` hook on the agent's Bash invocations watches for `specialist-wrapper` calls; on success the mark is cleared, on failure the commit is reverted and an entry is appended to `tenants/<id>/rollback.log`.
+
+## Scope enforcement (`SafeFs`)
+
+The architecture doc says scope limits should be "enforced via filesystem permissions, not just convention." `src/skills/safe-fs.ts` is the gate every meta-tool and registry write goes through. It rejects any path outside the allowlist:
+
+- `.claude/skills/**` — skill files
+- `services/**` — generated wrapper functions
+- `.specialist-state.json` — proving tracker
+- `rollback.log` — rollback audit trail
+
+Anything else throws `ScopeViolationError`. Verify with `npx tsx examples/safefs-check.ts` (covers absolute paths, `..` traversal, and non-allowlisted directories).
+
+## Parameter confirmation pass
+
+Spec: *"synthesis output is shown to the user with each candidate variable highlighted ('Is `\"USD\"` a wrapper input or a constant?'). One confirmation pass per wrapper."*
+
+After synthesis, every parameter on every newly synthesized wrapper is presented to the host's `confirmParameter` hook with the value observed in the trace. The host returns either `{ action: "keep" }` or `{ action: "freeze", constantValue }`. Frozen parameters are inlined into the wrapper's URL template + function body and removed from the spec — so the agent will never pass them as arguments.
+
+CLI:
+
+```bash
+# Interactive — prompt for each parameter
+specialist-agent learn --tenant=tenants/acme --har=./trace.har --intent="..."
+
+# Non-interactive — keep all parameters as the model proposed them
+specialist-agent learn --tenant=tenants/acme --har=./trace.har --intent="..." --auto-keep
+```
+
+The `npm run demo` path uses `--auto-keep` semantics for non-interactive runs.
 
 ## What's deliberately not here
 
@@ -148,14 +183,16 @@ Per the architecture doc:
 
 - **No frame/screen capture.** HTTP is the source of truth for v1.
 - **No streaming relevance filter.** Filtering happens at synthesis time on the trimmed trace.
-- **No multi-recording parameter inference.** A single trace + a confirmation pass handles ambiguity.
+- **No multi-recording parameter inference.** A single trace + the confirmation pass handles ambiguity.
 - **No smart wrapper functions.** Wrappers stay thin. Logic lives in workflows or agent reasoning.
-- **No self-modification beyond skills.** The meta tools cannot touch the auth broker, the runtime, or themselves — only files under the tenant workspace's `.claude/skills/` and `services/`.
+- **No self-modification beyond skills.** The meta tools cannot touch the auth broker, the runtime, or themselves — enforced by `SafeFs` allowlist.
 
 ## Scripts
 
 ```bash
 npm run typecheck     # tsc --noEmit
 npm run build         # emit dist/
-npm run demo          # examples/demo.ts
+npm run demo          # examples/demo.ts (end-to-end synthesis)
+npx tsx examples/safefs-check.ts    # SafeFs scope-rejection assertions
+npx tsx examples/proving-check.ts   # auto-rollback tracker assertions
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,161 @@
 # specialist-agent
-Specialist Agent
+
+A learning agent built on the [Claude Agent SDK](https://docs.claude.com/en/agent-sdk/typescript) that observes customer workflows once and replays them as skills.
+
+The full architecture is described in `docs/ARCHITECTURE.md` (the design doc this repo was built from). This README covers how the pieces fit together in code.
+
+## What's here
+
+```
+src/
+  agent.ts                  SpecialistAgent — wraps query() with tenant skills + meta tools
+  types.ts                  HttpTrace, SkillMetadata, SynthesisResult, etc.
+  auth/                     Pluggable auth broker (api-key, OAuth, SDK-embedded)
+  capture/                  Fetch interceptor + HAR import + auth scrubbing
+  synthesis/                Single Claude call: trace + intent → wrapper + workflow skills
+  skills/
+    registry.ts             Git-backed skill CRUD (commit/branch/merge/revert)
+    meta.ts                 meta.update_skill MCP server (reactive_fix, update_wrapper, add_workflow)
+  execution/
+    runner.ts               runWrapper(): the only HTTP touchpoint for generated wrappers
+    replay.ts               Validates a wrapper against live or staging endpoints
+  tenant/workspace.ts       Per-tenant filesystem layout + git init
+  cli/
+    main.ts                 specialist-agent learn|run|log
+    wrapper.ts              specialist-wrapper <vendor> <fn> --arg=val (the agent shells out to this)
+examples/
+  stripe-trace.har          Sample HAR — bills a new customer
+  demo.ts                   End-to-end: import HAR → synthesize → run agent
+```
+
+## Install
+
+```bash
+npm install
+```
+
+Requires Node 20+ and an `ANTHROPIC_API_KEY` for synthesis. Per-vendor API keys (e.g. `STRIPE_API_KEY`) are read at wrapper invocation time by the auth broker.
+
+## Quick demo
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-... npm run demo
+```
+
+This:
+
+1. Imports `examples/stripe-trace.har` (4 Stripe API calls: create customer → create invoice → add line item → finalize).
+2. Calls Claude to synthesize four wrapper skills + one workflow skill.
+3. Writes them to `tenants/demo/.claude/skills/` and `tenants/demo/services/stripe.ts`.
+4. Commits everything to a per-tenant git repo.
+
+Inspect the result:
+
+```bash
+ls tenants/demo/.claude/skills/
+cat tenants/demo/.claude/skills/<workflow_name>/SKILL.md
+git -C tenants/demo log --oneline
+```
+
+To also exercise the agent loop against the synthesized skills, set `RUN_AGENT=1` and provide `STRIPE_API_KEY`.
+
+## CLI
+
+```bash
+# Learn from a HAR export of an observed task.
+specialist-agent learn \
+  --tenant=tenants/acme \
+  --har=./acme-onboarding.har \
+  --intent="Onboard a new enterprise customer with first invoice"
+
+# Run the agent against the tenant's learned skills.
+specialist-agent run --tenant=tenants/acme "Onboard widgets-co with $2000 setup"
+
+# Tail the audit log (just `git log` over the skill repo).
+specialist-agent log --tenant=tenants/acme
+```
+
+## Embedding
+
+Use the `SpecialistAgent` class to host the agent inside your own application:
+
+```ts
+import {
+  SpecialistAgent,
+  AuthBroker,
+  SdkEmbeddedProvider,
+  setDefaultBroker,
+} from "specialist-agent";
+
+// Wire your own credential resolution — the agent never sees raw secrets at rest.
+setDefaultBroker(
+  new AuthBroker().register(
+    new SdkEmbeddedProvider(async (vendor) => {
+      if (vendor === "stripe") return { scheme: "bearer", token: await myVault.get("stripe") };
+      return null;
+    }),
+  ),
+);
+
+const agent = new SpecialistAgent({
+  tenant: { id: "acme", workspacePath: "/var/lib/specialist/tenants/acme" },
+  confirmInstructedChange: async (summary) => myUI.confirm(summary),
+});
+
+for await (const msg of agent.run("Bill alice@example.com $500 for April")) {
+  // stream messages to your UI
+}
+```
+
+## How a task runs
+
+1. The agent's system prompt describes the two-layer skill model and gives it the wrapper CLI invocation format.
+2. The Agent SDK loads tenant skills from `.claude/skills/<name>/SKILL.md` via `settingSources: ["project"]` with `cwd` set to the tenant root.
+3. The skill matcher picks the best workflow (or wrapper, for atomic asks).
+4. The agent reads the workflow MD, identifies the right wrapper for each step, and shells out via `Bash`:
+
+   ```
+   npx tsx src/cli/wrapper.ts stripe create_customer --email=alice@example.com --name=Alice --tenant=tenants/acme
+   ```
+
+5. The wrapper imports `services/stripe.ts`, calls the named function, and prints JSON on stdout. The function uses `runWrapper()`, which delegates auth to the broker.
+6. If a wrapper call fails or returns an unexpected shape, the agent loads the wrapper's MD, the failure, and prior responses, then re-reasons. If the failure looks like persistent drift (not transient), it invokes `meta.update_skill.reactive_fix` to update the wrapper and replay-validate the change before merging.
+
+## Capture surfaces
+
+The architecture doc lists three: browser extension, MITM proxy, and SDK interceptor. This repo ships:
+
+- **`attachFetchInterceptor(session)`** — patches `globalThis.fetch` for the Node SDK-embedded path.
+- **`importHar(path, intent)`** — drop-in for browser DevTools / proxy / extension exports.
+
+Auth headers and obvious credential keys are scrubbed at capture time (`src/capture/scrub.ts`); nothing sensitive is persisted.
+
+## Self-updating skills (meta tools)
+
+The agent's runtime exposes three tools via the `specialist-meta` MCP server:
+
+| Tool             | Trigger                                       | Confirmation         | Validation                    |
+| ---------------- | --------------------------------------------- | -------------------- | ----------------------------- |
+| `reactive_fix`   | Wrapper call failed with persistent drift     | Auto                 | Replay; merge only on success |
+| `update_wrapper` | User instruction mid-task                     | Required (host hook) | Replay; merge only on success |
+| `add_workflow`   | User walks through a sequence in conversation | Required (host hook) | None (pure prose)             |
+
+Failed validations stay on a branch (`synth/...`, `meta/...`) so the host can review.
+
+## What's deliberately not here
+
+Per the architecture doc:
+
+- **No frame/screen capture.** HTTP is the source of truth for v1.
+- **No streaming relevance filter.** Filtering happens at synthesis time on the trimmed trace.
+- **No multi-recording parameter inference.** A single trace + a confirmation pass handles ambiguity.
+- **No smart wrapper functions.** Wrappers stay thin. Logic lives in workflows or agent reasoning.
+- **No self-modification beyond skills.** The meta tools cannot touch the auth broker, the runtime, or themselves — only files under the tenant workspace's `.claude/skills/` and `services/`.
+
+## Scripts
+
+```bash
+npm run typecheck     # tsc --noEmit
+npm run build         # emit dist/
+npm run demo          # examples/demo.ts
+```

--- a/README.md
+++ b/README.md
@@ -2,9 +2,49 @@
 
 A learning agent built on the [Claude Agent SDK](https://docs.claude.com/en/agent-sdk/typescript) that observes customer workflows once and replays them as skills.
 
-The full architecture is described in `docs/ARCHITECTURE.md` (the design doc this repo was built from). This README covers how the pieces fit together in code.
+## Documentation
 
-## What's here
+| Doc                                       | What's in it                                                            |
+| ----------------------------------------- | ----------------------------------------------------------------------- |
+| **This file**                             | Quickstart, install, project layout, scripts                            |
+| [`docs/USAGE.md`](docs/USAGE.md)          | End-to-end real-world walkthrough — capture → synthesize → run          |
+| [`docs/CAPTURE.md`](docs/CAPTURE.md)      | Three ways to capture HTTP traces: DevTools HAR, MITM proxy, SDK hook   |
+| [`docs/EMBEDDING.md`](docs/EMBEDDING.md)  | Programmatic API for embedding the agent in your own host application  |
+| [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) | Common errors and fixes                                       |
+
+## Install
+
+```bash
+npm install
+```
+
+Requires Node 20+. Set `ANTHROPIC_API_KEY` for synthesis. Per-vendor API keys (e.g. `STRIPE_API_KEY`) are read at wrapper invocation time by the auth broker.
+
+## 60-second quickstart
+
+```bash
+# 1. Verify the build works.
+npm run typecheck
+
+# 2. Verify the safety guardrails.
+npx tsx examples/safefs-check.ts    # scope enforcement
+npx tsx examples/proving-check.ts   # auto-rollback
+
+# 3. Run the synthesis demo against the bundled Stripe HAR.
+ANTHROPIC_API_KEY=sk-ant-... npm run demo
+```
+
+The demo synthesizes wrapper + workflow skills from `examples/stripe-trace.har` (a 4-call invoice flow) and commits them to `tenants/demo/`. After it runs:
+
+```bash
+ls tenants/demo/.claude/skills/
+cat tenants/demo/.claude/skills/<workflow_name>/SKILL.md
+git -C tenants/demo log --oneline
+```
+
+To exercise the full agent loop (synthesis → run prompt → execute wrappers → call live Stripe), see [`docs/USAGE.md`](docs/USAGE.md).
+
+## Project layout
 
 ```
 src/
@@ -16,6 +56,8 @@ src/
   skills/
     registry.ts             Git-backed skill CRUD (commit/branch/merge/revert)
     meta.ts                 meta.update_skill MCP server (reactive_fix, update_wrapper, add_workflow)
+    safe-fs.ts              Filesystem allowlist gate (scope enforcement)
+    proving.ts              Unproven tracker — auto-rollback on first-call failure
   execution/
     runner.ts               runWrapper(): the only HTTP touchpoint for generated wrappers
     replay.ts               Validates a wrapper against live or staging endpoints
@@ -25,174 +67,66 @@ src/
     wrapper.ts              specialist-wrapper <vendor> <fn> --arg=val (the agent shells out to this)
 examples/
   stripe-trace.har          Sample HAR — bills a new customer
-  demo.ts                   End-to-end: import HAR → synthesize → run agent
+  demo.ts                   End-to-end: import HAR → synthesize → commit
+  safefs-check.ts           SafeFs scope-rejection assertions
+  proving-check.ts          Auto-rollback tracker assertions
+docs/
+  USAGE.md                  Real-world walkthrough
+  CAPTURE.md                Capture surfaces
+  EMBEDDING.md              Host integration
+  TROUBLESHOOTING.md        Common errors
 ```
 
-## Install
+## CLI reference
 
 ```bash
-npm install
-```
-
-Requires Node 20+ and an `ANTHROPIC_API_KEY` for synthesis. Per-vendor API keys (e.g. `STRIPE_API_KEY`) are read at wrapper invocation time by the auth broker.
-
-## Quick demo
-
-```bash
-ANTHROPIC_API_KEY=sk-ant-... npm run demo
-```
-
-This:
-
-1. Imports `examples/stripe-trace.har` (4 Stripe API calls: create customer → create invoice → add line item → finalize).
-2. Calls Claude to synthesize four wrapper skills + one workflow skill.
-3. Writes them to `tenants/demo/.claude/skills/` and `tenants/demo/services/stripe.ts`.
-4. Commits everything to a per-tenant git repo.
-
-Inspect the result:
-
-```bash
-ls tenants/demo/.claude/skills/
-cat tenants/demo/.claude/skills/<workflow_name>/SKILL.md
-git -C tenants/demo log --oneline
-```
-
-To also exercise the agent loop against the synthesized skills, set `RUN_AGENT=1` and provide `STRIPE_API_KEY`.
-
-## CLI
-
-```bash
-# Learn from a HAR export of an observed task.
+# Synthesize skills from a HAR export of an observed task.
 specialist-agent learn \
-  --tenant=tenants/acme \
-  --har=./acme-onboarding.har \
-  --intent="Onboard a new enterprise customer with first invoice"
+  --tenant=tenants/<id> \
+  --har=./<file>.har \
+  --intent="<one-sentence description>" \
+  [--auto-keep]                 # skip parameter-confirmation prompt
 
 # Run the agent against the tenant's learned skills.
-specialist-agent run --tenant=tenants/acme "Onboard widgets-co with $2000 setup"
+specialist-agent run --tenant=tenants/<id> [--yes] "<prompt>"
 
 # Tail the audit log (just `git log` over the skill repo).
-specialist-agent log --tenant=tenants/acme
+specialist-agent log --tenant=tenants/<id>
 ```
 
-## Embedding
+## Architecture summary
 
-Use the `SpecialistAgent` class to host the agent inside your own application:
+Two-layer skills:
 
-```ts
-import {
-  SpecialistAgent,
-  AuthBroker,
-  SdkEmbeddedProvider,
-  setDefaultBroker,
-} from "specialist-agent";
+- **Layer 1 — wrappers.** One per HTTP endpoint observed during learning. `SKILL.md` describes when to use it and what it returns; a thin TypeScript function under `services/<vendor>.ts` builds the URL, injects auth, and returns the parsed response. Invoked by the agent via shell with `specialist-wrapper`.
+- **Layer 2 — workflows.** Pure markdown describing how to compose wrappers. The agent reads the workflow MD and orchestrates calls itself.
 
-// Wire your own credential resolution — the agent never sees raw secrets at rest.
-setDefaultBroker(
-  new AuthBroker().register(
-    new SdkEmbeddedProvider(async (vendor) => {
-      if (vendor === "stripe") return { scheme: "bearer", token: await myVault.get("stripe") };
-      return null;
-    }),
-  ),
-);
+Self-updating: the agent has a `meta.update_skill` MCP server with three tools (`reactive_fix`, `update_wrapper`, `add_workflow`) that let it modify its own skill set. Every change is a git commit on a per-tenant repo.
 
-const agent = new SpecialistAgent({
-  tenant: { id: "acme", workspacePath: "/var/lib/specialist/tenants/acme" },
-  confirmInstructedChange: async (summary) => myUI.confirm(summary),
-  // Spec's "Is `\"USD\"` a wrapper input or a constant?" pass — fires once
-  // per parameter on every newly synthesized wrapper. Default keeps all.
-  confirmParameter: async ({ wrapper, parameter, observedValue }) =>
-    myUI.askParameter({ wrapper, parameter, observedValue }),
-});
+| Guardrail                | Where                                            |
+| ------------------------ | ------------------------------------------------ |
+| Scope enforcement        | `src/skills/safe-fs.ts` — path allowlist         |
+| Replay before merge      | `src/execution/replay.ts` — gate on `mergeToMain`|
+| Auto-rollback            | `src/skills/proving.ts` + `PostToolUse` hooks    |
+| Confirmation pass        | `confirmParameter` hook + CLI prompt             |
+| Audit log                | `git log` over the tenant repo + `rollback.log`  |
 
-for await (const msg of agent.run("Bill alice@example.com $500 for April")) {
-  // stream messages to your UI
-}
-```
-
-## How a task runs
-
-1. The agent's system prompt describes the two-layer skill model and gives it the wrapper CLI invocation format.
-2. The Agent SDK loads tenant skills from `.claude/skills/<name>/SKILL.md` via `settingSources: ["project"]` with `cwd` set to the tenant root.
-3. The skill matcher picks the best workflow (or wrapper, for atomic asks).
-4. The agent reads the workflow MD, identifies the right wrapper for each step, and shells out via `Bash`:
-
-   ```
-   npx tsx src/cli/wrapper.ts stripe create_customer --email=alice@example.com --name=Alice --tenant=tenants/acme
-   ```
-
-5. The wrapper imports `services/stripe.ts`, calls the named function, and prints JSON on stdout. The function uses `runWrapper()`, which delegates auth to the broker.
-6. If a wrapper call fails or returns an unexpected shape, the agent loads the wrapper's MD, the failure, and prior responses, then re-reasons. If the failure looks like persistent drift (not transient), it invokes `meta.update_skill.reactive_fix` to update the wrapper and replay-validate the change before merging.
-
-## Capture surfaces
-
-The architecture doc lists three: browser extension, MITM proxy, and SDK interceptor. This repo ships:
-
-- **`attachFetchInterceptor(session)`** — patches `globalThis.fetch` for the Node SDK-embedded path.
-- **`importHar(path, intent)`** — drop-in for browser DevTools / proxy / extension exports.
-
-Auth headers and obvious credential keys are scrubbed at capture time (`src/capture/scrub.ts`); nothing sensitive is persisted.
-
-## Self-updating skills (meta tools)
-
-The agent's runtime exposes three tools via the `specialist-meta` MCP server:
-
-| Tool             | Trigger                                       | Confirmation         | Validation                    | Auto-rollback                      |
-| ---------------- | --------------------------------------------- | -------------------- | ----------------------------- | ---------------------------------- |
-| `reactive_fix`   | Wrapper call failed with persistent drift     | Auto                 | Replay; merge only on success | Yes (revert on first-call failure) |
-| `update_wrapper` | User instruction mid-task                     | Required (host hook) | Replay; merge only on success | Yes (revert on first-call failure) |
-| `add_workflow`   | User walks through a sequence in conversation | Required (host hook) | None (pure prose)             | N/A (no wrappers)                  |
-
-Failed validations stay on a branch (`synth/...`, `meta/...`) so the host can review.
-
-**Auto-rollback** (spec: "if a freshly-merged skill version fails on its first production invocation, the agent reverts the commit"). After a meta-tool merge, the affected wrapper is marked unproven in `tenants/<id>/.specialist-state.json`. A `PostToolUse` hook on the agent's Bash invocations watches for `specialist-wrapper` calls; on success the mark is cleared, on failure the commit is reverted and an entry is appended to `tenants/<id>/rollback.log`.
-
-## Scope enforcement (`SafeFs`)
-
-The architecture doc says scope limits should be "enforced via filesystem permissions, not just convention." `src/skills/safe-fs.ts` is the gate every meta-tool and registry write goes through. It rejects any path outside the allowlist:
-
-- `.claude/skills/**` — skill files
-- `services/**` — generated wrapper functions
-- `.specialist-state.json` — proving tracker
-- `rollback.log` — rollback audit trail
-
-Anything else throws `ScopeViolationError`. Verify with `npx tsx examples/safefs-check.ts` (covers absolute paths, `..` traversal, and non-allowlisted directories).
-
-## Parameter confirmation pass
-
-Spec: *"synthesis output is shown to the user with each candidate variable highlighted ('Is `\"USD\"` a wrapper input or a constant?'). One confirmation pass per wrapper."*
-
-After synthesis, every parameter on every newly synthesized wrapper is presented to the host's `confirmParameter` hook with the value observed in the trace. The host returns either `{ action: "keep" }` or `{ action: "freeze", constantValue }`. Frozen parameters are inlined into the wrapper's URL template + function body and removed from the spec — so the agent will never pass them as arguments.
-
-CLI:
+## Scripts
 
 ```bash
-# Interactive — prompt for each parameter
-specialist-agent learn --tenant=tenants/acme --har=./trace.har --intent="..."
-
-# Non-interactive — keep all parameters as the model proposed them
-specialist-agent learn --tenant=tenants/acme --har=./trace.har --intent="..." --auto-keep
+npm run typecheck                       # tsc --noEmit
+npm run build                           # emit dist/
+npm run demo                            # examples/demo.ts
+npx tsx examples/safefs-check.ts        # scope assertions
+npx tsx examples/proving-check.ts       # rollback assertions
 ```
-
-The `npm run demo` path uses `--auto-keep` semantics for non-interactive runs.
 
 ## What's deliberately not here
 
 Per the architecture doc:
 
 - **No frame/screen capture.** HTTP is the source of truth for v1.
-- **No streaming relevance filter.** Filtering happens at synthesis time on the trimmed trace.
-- **No multi-recording parameter inference.** A single trace + the confirmation pass handles ambiguity.
+- **No streaming relevance filter.** Filtering happens at synthesis time.
+- **No multi-recording parameter inference.** A single trace + confirmation pass handles ambiguity.
 - **No smart wrapper functions.** Wrappers stay thin. Logic lives in workflows or agent reasoning.
-- **No self-modification beyond skills.** The meta tools cannot touch the auth broker, the runtime, or themselves — enforced by `SafeFs` allowlist.
-
-## Scripts
-
-```bash
-npm run typecheck     # tsc --noEmit
-npm run build         # emit dist/
-npm run demo          # examples/demo.ts (end-to-end synthesis)
-npx tsx examples/safefs-check.ts    # SafeFs scope-rejection assertions
-npx tsx examples/proving-check.ts   # auto-rollback tracker assertions
-```
+- **No self-modification beyond skills.** Meta tools cannot touch auth, runtime, or themselves — enforced by `SafeFs`.

--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -1,0 +1,179 @@
+# Capturing HTTP traces
+
+The agent learns from HTTP traces. The architecture doc lists three capture surfaces; this repo ships full support for two and a recipe for the third.
+
+| Surface             | What for                                              | Status                            |
+| ------------------- | ----------------------------------------------------- | --------------------------------- |
+| Browser DevTools HAR| Web-app workflows the user drives in a browser       | Use `importHar()` / `--har=...`   |
+| MITM proxy HAR      | Native/desktop apps, mobile apps, anything not in DevTools | Use `importHar()` / `--har=...` |
+| `attachFetchInterceptor()` | Embedded inside a Node host that already makes the calls | First-class API in `src/capture/` |
+
+All three produce the same in-memory `HttpTrace` shape (see `src/types.ts`). Auth headers and obvious credential keys are scrubbed at capture time (`src/capture/scrub.ts`) — nothing sensitive is persisted.
+
+---
+
+## Surface 1: Browser DevTools (recommended for web SaaS)
+
+This is the easiest path for SaaS apps.
+
+1. Open your app in Chrome, Firefox, or Edge.
+2. Open DevTools (F12) → **Network** tab.
+3. Tick **Preserve log** so navigation doesn't clear the trace.
+4. Click **🚫** (clear) to start fresh.
+5. Perform the workflow you want the agent to learn — ideally once, end-to-end, no extra exploration.
+6. Right-click anywhere in the network list → **Save all as HAR with content** → save as e.g. `~/Downloads/onboarding.har`.
+7. Run synthesis:
+
+   ```bash
+   specialist-agent learn \
+     --tenant=tenants/acme \
+     --har=~/Downloads/onboarding.har \
+     --intent="Onboard a new enterprise customer with first invoice"
+   ```
+
+**Tips:**
+
+- **Filter to the relevant API host** before saving. Click **Filter** and type the API hostname (e.g. `api.stripe.com`) so you don't include analytics, fonts, telemetry, etc. The model can ignore noise but smaller traces synthesize faster and cheaper.
+- **One workflow per HAR.** Don't bundle "create customer" and "process refund" into one trace — synthesize them separately.
+- **Auth is automatically scrubbed.** `Authorization`, `Cookie`, `X-Api-Key`, etc. become `{{auth}}` before anything hits disk.
+
+---
+
+## Surface 2: MITM proxy
+
+For non-browser apps (desktop, native, mobile, server-to-server). Common tools:
+
+- [mitmproxy](https://mitmproxy.org/) — open source, scriptable
+- [Charles Proxy](https://www.charlesproxy.com/)
+- [Proxyman](https://proxyman.io/)
+
+### mitmproxy recipe
+
+```bash
+# 1. Start mitmproxy and tell the target app to use it.
+mitmproxy --listen-port 8080
+
+# 2. Trust the mitmproxy CA on the device running the workflow (one-time).
+#    See https://docs.mitmproxy.org/stable/concepts-certificates/
+
+# 3. Set HTTPS_PROXY / HTTP_PROXY for the target process.
+HTTPS_PROXY=http://localhost:8080 ./your-app
+
+# 4. Perform the workflow.
+
+# 5. Export the captured flows as HAR.
+#    In mitmproxy's UI: File → Save → HAR (>1.5 only). On older versions,
+#    use the bundled har_dump addon:
+mitmproxy --listen-port 8080 -s ~/path/to/har_dump.py --set hardump=onboarding.har
+
+# 6. Run synthesis with the exported HAR — same as the DevTools path.
+specialist-agent learn --tenant=tenants/acme --har=./onboarding.har --intent="..."
+```
+
+### Charles Proxy
+
+File → Export Session → HAR.
+
+### Proxyman
+
+File → Export → HAR.
+
+---
+
+## Surface 3: SDK fetch interceptor (embedded use)
+
+When the agent is embedded inside a Node host that *already* makes the API calls (e.g. an internal automation service), capture happens inline. No external proxy or browser needed.
+
+```ts
+import { startCapture, attachFetchInterceptor, SpecialistAgent } from "specialist-agent";
+
+const session = startCapture("Onboard a new enterprise customer with first invoice");
+const stop = attachFetchInterceptor(session);
+
+try {
+  // Drive the workflow through your normal code path. Every fetch() call
+  // — directly or via SDKs that use fetch() under the hood — is recorded.
+  await myStripeService.createCustomer({ email: "alice@example.com" });
+  await myStripeService.createInvoice({ /* ... */ });
+  // ...
+} finally {
+  stop(); // restore the original fetch
+}
+
+const trace = session.finish();
+
+// Hand the trace to the agent for synthesis.
+const agent = new SpecialistAgent({
+  tenant: { id: "acme", workspacePath: "/var/lib/specialist/tenants/acme" },
+});
+const result = await agent.learnFromTrace(trace);
+console.log(`Synthesized: ${result.workflow}, ${result.wrappers.length} wrappers`);
+```
+
+The interceptor:
+
+- Patches `globalThis.fetch` for the duration of the capture session.
+- Reads request method/URL/headers/body.
+- Reads response status/headers/body (clones the response so the caller still gets a fresh body).
+- Stops automatically when you call `stop()`. Always call it (e.g. in a `finally`) so subsequent fetches aren't intercepted.
+
+**What it does not capture:**
+
+- HTTP calls made via Node's `http`/`https` modules directly (most SDKs use fetch in modern Node, but some old ones don't).
+- Calls from a child process. Re-launch with the interceptor, or use a MITM proxy.
+
+---
+
+## Anatomy of an `HttpTrace`
+
+All three surfaces produce this shape:
+
+```ts
+interface HttpTrace {
+  id: string;
+  startedAt: string;       // ISO 8601
+  endedAt: string;
+  intent: string;          // one-sentence task description
+  requests: HttpExchange[];
+}
+
+interface HttpExchange {
+  index: number;
+  request: {
+    method: string;        // GET, POST, ...
+    url: string;
+    headers: Record<string, string>;  // auth values are {{auth}}
+    body: unknown;         // parsed JSON if Content-Type was JSON, else string
+    timestamp: string;
+  };
+  response: {
+    status: number;
+    headers: Record<string, string>;
+    body: unknown;
+    durationMs: number;
+  };
+}
+```
+
+You can construct an `HttpTrace` directly if you have a non-standard capture source — synthesis only cares about the shape.
+
+---
+
+## Auth scrubbing
+
+The scrubber (`src/capture/scrub.ts`) replaces:
+
+- **Headers** named: `authorization`, `x-api-key`, `api-key`, `x-auth-token`, `x-access-token`, `cookie`, `set-cookie`, `proxy-authorization`.
+- **JSON keys** matching: `api_key`, `apikey`, `access_token`, `refresh_token`, `client_secret`, `password`, `secret`.
+- **String bodies** containing `Bearer <token>` patterns.
+
+This is a heuristic — not a guarantee. Synthesis is the second line of defense; it never echoes credential-shaped values into generated wrappers because of how the prompt frames the task. If you have unusual auth schemes (custom header names, etc.), extend `AUTH_HEADER_NAMES` in `scrub.ts`.
+
+---
+
+## What makes a good capture
+
+- **One task end-to-end.** Don't bundle multiple workflows.
+- **Minimal exploration.** The trace should reflect the *successful* path, not all the false starts.
+- **No retries with old auth.** If the user has expired tokens that triggered a refresh in the middle of capture, separate the refresh into its own learn call (or remove those exchanges from the HAR before synthesis).
+- **One vendor per call.** Don't capture a workflow that hits both Stripe and Slack and try to synthesize one workflow. Synthesize a Stripe workflow and a Slack workflow separately, then capture a higher-level workflow that *composes* them — the agent will discover the existing wrappers and stitch them.

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -1,0 +1,253 @@
+# Embedding the agent
+
+How to host the specialist agent inside your own application (instead of driving it through the CLI).
+
+The CLI is a thin wrapper around the public TypeScript API exported from `src/index.ts`. Anything the CLI does, your code can do.
+
+```ts
+import {
+  SpecialistAgent,
+  AuthBroker,
+  ApiKeyProvider,
+  SdkEmbeddedProvider,
+  setDefaultBroker,
+  importHar,
+  startCapture,
+  attachFetchInterceptor,
+  type ParameterDecision,
+} from "specialist-agent";
+```
+
+---
+
+## Minimal lifecycle
+
+```ts
+// 1. Boot the agent for a tenant.
+const agent = new SpecialistAgent({
+  tenant: {
+    id: "acme",
+    workspacePath: "/var/lib/specialist/tenants/acme",
+  },
+});
+
+// 2. (Once, after capturing a trace) — synthesize new skills.
+const trace = await importHar("/tmp/onboarding.har", "Onboard enterprise customer");
+const learned = await agent.learnFromTrace(trace);
+console.log(`Workflow: ${learned.workflow}, wrappers: ${learned.wrappers.join(", ")}`);
+
+// 3. Run prompts against the tenant's skills.
+for await (const msg of agent.run("Onboard widgets-co with $2000 setup")) {
+  if (msg.type === "assistant") {
+    for (const block of msg.message.content) {
+      if (block.type === "text") process.stdout.write(block.text);
+    }
+  }
+}
+```
+
+`SpecialistAgent` is per-tenant. Construct one per tenant; reuse it across many calls. `agent.run()` returns an async generator yielding standard Agent SDK `SDKMessage` objects — pass them to your UI streaming layer as you would for any Claude Agent SDK app.
+
+---
+
+## Auth providers
+
+Wrappers ask the broker for credentials at call time. Three built-in providers:
+
+```ts
+// 1. API keys from environment (default).
+//    Reads <VENDOR>_API_KEY (uppercased), e.g. STRIPE_API_KEY.
+new ApiKeyProvider({ scheme: "bearer" });
+
+// 2. Custom-header schemes (e.g. X-API-Key for some vendors).
+new ApiKeyProvider({ scheme: "header", field: "X-Api-Key" });
+
+// 3. Query-param schemes.
+new ApiKeyProvider({ scheme: "query", field: "api_key" });
+
+// 4. Host-supplied callback — credentials never sit in env.
+new SdkEmbeddedProvider(async (vendor) => {
+  const token = await mySecretsManager.get(`tenants/acme/${vendor}/api-key`);
+  if (!token) return null;
+  return { scheme: "bearer", token };
+});
+
+// 5. OAuth tokens with caller-managed refresh.
+new OAuthProvider({
+  get: async (vendor) => myTokenStore.get(vendor),
+  refreshIfExpired: async (vendor) => myTokenStore.refresh(vendor),
+});
+```
+
+Wire them up once at process boot:
+
+```ts
+import { AuthBroker, SdkEmbeddedProvider, ApiKeyProvider, setDefaultBroker } from "specialist-agent";
+
+setDefaultBroker(
+  new AuthBroker()
+    // Try host-supplied first, fall back to env vars.
+    .register(new SdkEmbeddedProvider(async (vendor) => {
+      const token = await myVault.get(`stripe-${currentTenantId()}`);
+      if (vendor === "stripe" && token) return { scheme: "bearer", token };
+      return null;
+    }))
+    .register(new ApiKeyProvider({ scheme: "bearer" })),
+);
+```
+
+Providers are tried in registration order; the first that returns `canHandle: true` wins.
+
+**The agent never sees raw secrets at rest.** The broker is consulted at the moment of each HTTP call, inside `runWrapper()`. The token never enters the prompt or the agent's reasoning context.
+
+---
+
+## Confirmation hooks
+
+Two hooks on `SpecialistAgentOptions` correspond to the spec's two human-in-the-loop points:
+
+```ts
+const agent = new SpecialistAgent({
+  tenant: { id: "acme", workspacePath: "..." },
+
+  // Spec: "Is `\"USD\"` a wrapper input or a constant?"
+  // Fires once per parameter on every newly synthesized wrapper.
+  confirmParameter: async ({ wrapper, parameter, observedValue }) => {
+    const decision = await myUI.askConstant({
+      wrapper: wrapper.name,
+      parameter: parameter.name,
+      observed: observedValue,
+    });
+    return decision === "constant"
+      ? { action: "freeze", constantValue: observedValue }
+      : { action: "keep" };
+  },
+
+  // Spec: "user-instructed changes require an explicit confirm step."
+  // Fires when the agent calls meta.update_wrapper or meta.add_workflow.
+  confirmInstructedChange: async (summary) => {
+    return myUI.confirmDialog({ title: "Approve skill change?", body: summary });
+  },
+});
+```
+
+Both hooks default to "yes" (keep parameter / approve change) when omitted, which is what the demo and `--auto-keep` CLI mode do.
+
+`reactive_fix` (the auto-fix-on-API-drift path) does **not** consult `confirmInstructedChange` — it applies automatically per the spec. If you want to gate that too, wrap `agent.run()` in your own approval queue.
+
+---
+
+## Capturing inline
+
+When the agent is embedded inside the same process that makes the API calls, use `attachFetchInterceptor` to capture without a proxy:
+
+```ts
+import { startCapture, attachFetchInterceptor } from "specialist-agent";
+
+async function captureAndLearn(intent: string, runWorkflow: () => Promise<void>) {
+  const session = startCapture(intent);
+  const stop = attachFetchInterceptor(session);
+  try {
+    await runWorkflow();
+  } finally {
+    stop();
+  }
+  const trace = session.finish();
+  return agent.learnFromTrace(trace);
+}
+
+await captureAndLearn(
+  "Onboard a new enterprise customer with first invoice",
+  async () => {
+    await myStripeService.createCustomer({ email: "alice@example.com" });
+    await myStripeService.createInvoice({ /* ... */ });
+  },
+);
+```
+
+See [`CAPTURE.md`](./CAPTURE.md) for the complete capture-surface guide.
+
+---
+
+## Per-tenant isolation
+
+Each tenant gets its own:
+
+- Workspace directory (its own filesystem root)
+- Git repo (its own audit history)
+- Skills (no cross-tenant leakage)
+- Service code (no cross-tenant leakage)
+- Unproven tracker / rollback log
+
+Constructing one `SpecialistAgent` per tenant is the right pattern. Cache them in a `Map<tenantId, SpecialistAgent>` keyed by tenant ID.
+
+```ts
+class AgentRegistry {
+  private cache = new Map<string, SpecialistAgent>();
+
+  for(tenantId: string): SpecialistAgent {
+    let agent = this.cache.get(tenantId);
+    if (!agent) {
+      agent = new SpecialistAgent({
+        tenant: {
+          id: tenantId,
+          workspacePath: `/var/lib/specialist/tenants/${tenantId}`,
+        },
+        confirmParameter: this.confirmParameter,
+        confirmInstructedChange: this.confirmInstructedChange,
+      });
+      this.cache.set(tenantId, agent);
+    }
+    return agent;
+  }
+}
+```
+
+The agent is stateless apart from the workspace directory and the in-memory `query()` session, so it's safe to construct many — overhead is negligible.
+
+---
+
+## Lower-level APIs
+
+If you want to compose the pieces yourself instead of using `SpecialistAgent`:
+
+```ts
+import {
+  TenantWorkspace,
+  SkillRegistry,
+  synthesizeFromTrace,
+  replayWrapper,
+  importHar,
+} from "specialist-agent";
+
+const workspace = new TenantWorkspace({ id: "acme", workspacePath: "/var/lib/.../acme" });
+await workspace.ensure();
+const registry = new SkillRegistry(workspace);
+
+const trace = await importHar("/tmp/x.har", "Bill a customer");
+const result = await synthesizeFromTrace({ trace, existingWrappers: [] });
+
+// ... apply parameter decisions yourself ...
+
+await registry.checkoutBranch(`synth/${result.workflow.name}-${Date.now()}`);
+await registry.writeSynthesisResult(result);
+
+// Validate each wrapper.
+for (const w of result.wrappers) {
+  const r = await replayWrapper({
+    workspace, spec: w.spec, testArgs: { /* ... */ }, dryRun: true,
+  });
+  if (!r.success) { /* handle */ }
+}
+
+await registry.commit({ trigger: "synthesis", actor: "human", message: "..." });
+await registry.mergeToMain("synth/...");
+```
+
+This is what `SpecialistAgent.learnFromTrace` does internally, with the extra confirmation/replay/auto-rollback machinery wired up.
+
+---
+
+## What you cannot override
+
+The architecture doc is strict about scope: the agent's self-modification is filesystem-scoped via `SafeFs`. Even from embedded code, you can't relax that by passing options — the allowlist is hard-coded into the workspace. If you need broader scope (e.g. you want the agent to edit its own auth broker), that's a fork-and-modify situation and you should reconsider whether you actually want it.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,173 @@
+# Troubleshooting
+
+Common errors during synthesis, replay, and run.
+
+---
+
+## Synthesis
+
+### `AuthenticationError: 401 ... invalid x-api-key`
+
+`ANTHROPIC_API_KEY` is missing or wrong. The key is read at the moment `synthesizeFromTrace` makes its call, not at agent construction time.
+
+```bash
+echo "$ANTHROPIC_API_KEY"   # should print sk-ant-...
+```
+
+### `Synthesis call returned no tool_use block.`
+
+The model produced text instead of invoking the schema. Causes:
+
+- Trace is empty (HAR contains no exchanges, or every exchange got filtered).
+- Trace is enormous and the model refused. Filter to only the relevant API host before exporting.
+- Quota / rate limit. Check `https://status.anthropic.com` and your usage dashboard.
+
+### Generated wrappers reference parameters the trace doesn't actually use
+
+This is what the parameter-confirmation pass exists for. Synthesis sometimes invents parameters that look reasonable from one trace but are constants in your workflow. Run `learn` interactively (without `--auto-keep`), and freeze the spurious parameters when prompted.
+
+If you already merged a wrapper with a bogus parameter, ask the agent to fix it: `specialist-agent run --tenant=... "Update stripe.create_invoice — drop the 'foo' parameter, it should always be 'bar'"`. The agent will call `meta.update_skill.update_wrapper`, you confirm the summary, and it's replay-validated and merged.
+
+---
+
+## Replay validation
+
+### `function "<name>" not exported from <file>`
+
+The model emitted an `implementation` block that doesn't map to a single exported function — usually because the wrapper name has unusual characters. Wrapper names use dotted form (`<vendor>.<verb_object>`) and the function name is the part after the last dot. Inspect `services/<vendor>.ts`, find the actual export, and compare to the SKILL.md.
+
+### `failed to load <file>: SyntaxError: ...`
+
+Synthesis emitted invalid TypeScript. Rare but possible. The `synth/...` branch will retain the broken file; merge to main was blocked. Fix the file by hand on the branch, push, and merge:
+
+```bash
+git -C tenants/<id> checkout synth/<workflow>-<timestamp>
+# fix services/<vendor>.ts
+git -C tenants/<id> commit -am "fix: synthesized wrapper had a syntax error"
+git -C tenants/<id> checkout main
+git -C tenants/<id> merge --ff-only synth/<workflow>-<timestamp>
+```
+
+Then ping the issue tracker — repeated occurrences mean the synthesis prompt needs tightening.
+
+---
+
+## Agent run
+
+### Agent picks the wrong skill
+
+The Skill tool selects based on the description in each SKILL.md frontmatter. If the agent keeps choosing the wrong workflow, the descriptions are too similar or too generic. Edit `.claude/skills/<name>/SKILL.md` and tighten the `description:` line — make sure the "Use when:" portion is concrete and distinguishing. Commit the change directly:
+
+```bash
+git -C tenants/<id> commit -am "tighten description for <workflow>"
+```
+
+### `wrapper failed: <vendor> ... 401 Unauthorized`
+
+The auth broker returned a credential, but the vendor rejected it. Check:
+
+- `<VENDOR>_API_KEY` env var is set (or your `SdkEmbeddedProvider` returns one).
+- The token has the necessary scopes.
+- The token isn't expired (for OAuth tokens — the `OAuthProvider.refreshIfExpired` callback should handle this).
+
+### Auto-rollback fired when it shouldn't have
+
+If the wrapper's first post-meta-merge call returned non-zero exit, the rollback hook reverted. Check `tenants/<id>/rollback.log` — the entry will say what the failure looked like. Common causes:
+
+- Transient 5xx — should not have triggered rollback. The wrapper CLI exits non-zero on any error; we don't yet distinguish transient from permanent. If this is recurrent, file an issue.
+- The user-instructed change actually broke things — the rollback was correct.
+- The "first invocation" was a wrapper call from a *different* run that happened to fail for an unrelated reason. The unproven tracker is keyed by wrapper name, not session ID.
+
+To re-attempt the change: `specialist-agent run --tenant=... "Re-apply the change to <wrapper> — ..."`. The agent will call `meta.update_skill.update_wrapper` again and re-mark unproven.
+
+### `git revert` failed during auto-rollback
+
+Means the unproven commit had already been further modified (e.g. another meta-edit landed on top before the first invocation). `failUnproven` will throw; the rollback log won't have an entry. Inspect manually:
+
+```bash
+git -C tenants/<id> log --oneline
+git -C tenants/<id> revert <hash>     # interactively resolve
+```
+
+This is a rare edge case — meta-edits to the same wrapper in rapid succession.
+
+---
+
+## SafeFs / scope violations
+
+### `ScopeViolationError: path "..." is not in the SafeFs allowlist`
+
+The agent (or your code) tried to write somewhere outside the allowlisted prefixes. This is the guardrail working as intended — investigate what the call site was trying to do.
+
+If you're writing legitimate host-side state that the agent shouldn't touch, store it *outside* the tenant workspace. The allowlist exists to prevent the agent from escaping; host code should respect the same boundary by storing its own state elsewhere.
+
+If you have a genuine reason to extend the allowlist (e.g. the agent writes generated test fixtures to `tests/` in the tenant workspace), add the prefix in `src/skills/safe-fs.ts:assertWithin`. Be conservative — every prefix added is one more place the agent can write under prompt injection.
+
+---
+
+## Capture
+
+### HAR import skips entries silently
+
+`importHar` handles standard HAR 1.2. If your tool exports a non-standard variant (some MITM proxies' HAR has missing fields), check the import:
+
+```ts
+import { importHar } from "specialist-agent";
+const trace = await importHar("/tmp/x.har", "...");
+console.log(`${trace.requests.length} exchanges imported`);
+```
+
+If the count is lower than expected, inspect the raw HAR for missing required fields (`startedDateTime`, `request.method`, `request.url`, `response.status`).
+
+### Fetch interceptor doesn't capture some calls
+
+`attachFetchInterceptor` patches `globalThis.fetch`. It does NOT capture:
+
+- Calls via Node's `http`/`https` modules directly.
+- Calls from a worker thread (each thread has its own `globalThis`).
+- Calls from a child process.
+
+For these, use a MITM proxy (see `CAPTURE.md`).
+
+### Auth scrubbing missed something sensitive
+
+`src/capture/scrub.ts` is heuristic. Expand the header list or the JSON-key regex if your vendor uses a non-standard credential shape, and verify by inspecting the trace before synthesis:
+
+```ts
+const trace = await importHar("/tmp/x.har", "...");
+console.log(JSON.stringify(trace, null, 2));
+```
+
+Synthesis is the second line of defense — the prompt is structured so the model treats `{{auth}}` as opaque and never echoes raw values. But if you see real credentials in the trace, fix the scrubber before running synthesis.
+
+---
+
+## Build / install
+
+### `Cannot find name 'RequestInfo'` etc. on typecheck
+
+`tsconfig.json` lib must include `DOM` for the fetch interceptor's types. The repo's tsconfig already does this; if you're embedding from another project with a different config, add:
+
+```json
+"lib": ["ES2023", "DOM"]
+```
+
+### `npm install` fails fetching `@anthropic-ai/claude-agent-sdk`
+
+Make sure your registry config can reach `registry.npmjs.org`. The package isn't private.
+
+### `npx tsx` warns about `punycode` deprecation
+
+Cosmetic. Comes from a transitive dependency in Node 22+. Ignore.
+
+---
+
+## Where to look when something else breaks
+
+1. **Tenant git log.** Every skill change records trigger / actor / replay outcome in the commit message body. `git -C tenants/<id> log --pretty=full` is the audit trail.
+2. **rollback.log.** If the proving tracker reverted something, here's why.
+3. **`.specialist-state.json`.** Lists wrappers currently flagged as unproven (waiting for first-invocation proof).
+4. **Set `ANTHROPIC_LOG=info`.** SDK-level request logging from `@anthropic-ai/sdk`.
+5. **Run with one wrapper.** Edit a HAR down to one exchange to isolate which wrapper is misbehaving.
+
+If you've narrowed the problem and it still doesn't make sense, file an issue with: tenant id (or anonymized snippet of `git log`), the synthesis output that produced the wrapper, the failing prompt, and any relevant `rollback.log` entries.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,211 @@
+# Real-world walkthrough
+
+End-to-end recipe for taking the specialist agent from "freshly cloned" to "running real tasks against a real API." Uses Stripe as the running example because the bundled HAR fixture targets it; the same flow works for any vendor whose API can be hit with a bearer token.
+
+> **Cost note.** The synthesis step makes one Claude API call per `learn` invocation (input ≈ size of the trace; output ≈ size of all generated skills). With prompt caching on the system prompt, the second `learn` for the same tenant is cheaper. The `run` command is a normal Agent SDK loop — cost depends on how complex the task is. Set `ANTHROPIC_LOG=info` if you want to see request sizes.
+
+---
+
+## 0. Prerequisites
+
+```bash
+node --version          # ≥ 20
+git --version           # ≥ 2.30
+npm install
+npm run typecheck       # should print nothing on success
+```
+
+Set:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+Verify the safety machinery works before doing anything else:
+
+```bash
+npx tsx examples/safefs-check.ts
+npx tsx examples/proving-check.ts
+```
+
+Both should end with `All ... assertions passed.` If either fails, do not continue — something in the build is wrong.
+
+---
+
+## 1. Capture an HTTP trace
+
+You need a HAR file representing the workflow you want the agent to learn. Three options:
+
+| Source                     | When to use                                              |
+| -------------------------- | -------------------------------------------------------- |
+| Browser DevTools (HAR)     | Web app workflows the user drives in a browser          |
+| MITM proxy (mitmproxy etc.)| Native/desktop app or any traffic not in a browser      |
+| `attachFetchInterceptor()` | Embedded inside a Node host that already makes the calls |
+
+Detailed instructions per surface live in [`CAPTURE.md`](./CAPTURE.md). For this walkthrough we'll use the bundled `examples/stripe-trace.har` so you can follow along without setting up capture.
+
+---
+
+## 2. Synthesize skills from the trace
+
+```bash
+specialist-agent learn \
+  --tenant=tenants/acme \
+  --har=examples/stripe-trace.har \
+  --intent="Bill a new customer for Q2 consulting fees"
+```
+
+What happens:
+
+1. The HAR is parsed and auth headers are scrubbed (`{{auth}}` placeholders) before anything is persisted.
+2. One Claude call (Opus 4.7) takes the trace + intent + your existing wrapper list and returns wrapper specs + a workflow.
+3. **Parameter confirmation pass.** For each parameter on each new wrapper you'll see:
+
+   ```
+   stripe.create_invoice — parameter `currency` (string, optional)
+     observed in trace: "usd"
+     [k]eep as parameter / [f]reeze as constant? [k]
+   ```
+
+   Press Enter (or `k`) to keep it as a parameter. Press `f` to freeze it as a constant — the value gets inlined into the wrapper body and the parameter is dropped from the spec. Use this when the model invents a parameter that's actually a constant in your workflow (currencies, account IDs, version strings, etc.).
+
+   Skip the prompt entirely with `--auto-keep` for non-interactive runs.
+
+4. Each new wrapper is replay-validated (dry-run by default — confirms the function loads and exports correctly).
+5. Everything commits to the tenant's git repo on a `synth/...` branch and merges to `main` if validation passes. Failed validation stays on the branch for review.
+
+Inspect the output:
+
+```bash
+ls tenants/acme/.claude/skills/
+# create_paid_invoice_for_new_customer/
+# stripe.create_customer/
+# stripe.create_invoice/
+# stripe.create_invoiceitem/
+# stripe.finalize_invoice/
+
+cat tenants/acme/.claude/skills/create_paid_invoice_for_new_customer/SKILL.md
+cat tenants/acme/services/stripe.ts
+git -C tenants/acme log --oneline
+# b1c2d3e synth: create_paid_invoice_for_new_customer (4 wrappers) — Bill a new customer for Q2 consulting fees
+# 0ed868b init tenant workspace
+```
+
+---
+
+## 3. Provide vendor credentials
+
+Wrappers call out via the auth broker. The default broker reads `<VENDOR>_API_KEY` from the environment as a bearer token. For Stripe:
+
+```bash
+export STRIPE_API_KEY="sk_test_..."
+```
+
+For more elaborate auth (OAuth tokens with refresh, secrets manager lookup, multi-tenant credential isolation), wire the `SdkEmbeddedProvider` — see [`EMBEDDING.md`](./EMBEDDING.md) §"Auth providers."
+
+---
+
+## 4. Run the agent
+
+```bash
+specialist-agent run --tenant=tenants/acme \
+  "Bill alice@example.com $500 for April consulting (30-day net terms)"
+```
+
+What you'll see (paraphrased):
+
+```
+I'll bill Alice for the consulting work using the create_paid_invoice_for_new_customer workflow.
+
+Step 1: Create the customer.
+[bash: specialist-wrapper stripe create_customer --email=... --tenant=tenants/acme]
+{"id":"cus_QrSt...","object":"customer",...}
+
+Step 2: Create the invoice.
+[bash: specialist-wrapper stripe create_invoice --customer=cus_QrSt... --tenant=tenants/acme]
+...
+
+Done. Invoice in_1Ox... is open. Amount due: $500.
+```
+
+The agent loop:
+
+1. The skill matcher picks the workflow.
+2. The agent reads the workflow MD, identifies the right wrapper for each step, extracts arguments, and shells out via Bash.
+3. The wrapper runs `runWrapper()`, which fetches credentials from the broker, builds the HTTP request, sends it, and returns parsed JSON on stdout.
+4. The agent parses the output, extracts the values it needs (e.g. `cus_...` → next step's `customer` argument), and continues.
+5. On any failure, the agent loads the wrapper's SKILL.md, the failed request/response, and prior responses, and re-reasons. Persistent drift triggers `meta.update_skill.reactive_fix`.
+
+---
+
+## 5. Watch the auto-rollback in action
+
+To see the spec's "freshly merged skill that fails on first invocation auto-reverts" guardrail fire end-to-end:
+
+```bash
+# Drive the agent into making a meta-edit that breaks something.
+specialist-agent run --tenant=tenants/acme --yes \
+  "I noticed the create_invoice wrapper now needs a 'tax_rate' parameter. Update it to send tax_rate=0 by default and try the workflow again."
+
+# After that turn:
+cat tenants/acme/rollback.log     # entry showing the revert
+git -C tenants/acme log --oneline # shows: meta: ..., then Revert "meta: ..."
+```
+
+The agent calls `meta.update_skill.update_wrapper`, which merges the change to main and marks the wrapper unproven. When the next `specialist-wrapper` invocation comes back with a non-zero exit, the `PostToolUse` hook calls `failUnproven`, which `git revert`s the bad commit and writes to `rollback.log`.
+
+---
+
+## 6. Inspect what was learned
+
+```bash
+# All skills
+ls tenants/acme/.claude/skills/
+
+# Workflow MD
+cat tenants/acme/.claude/skills/create_paid_invoice_for_new_customer/SKILL.md
+
+# One wrapper
+cat tenants/acme/.claude/skills/stripe.create_customer/SKILL.md
+
+# Generated TypeScript (the actual HTTP-call code)
+cat tenants/acme/services/stripe.ts
+
+# Audit log — every commit records trigger/actor/replay outcome in the message body
+git -C tenants/acme log --pretty=full
+
+# Rollbacks (if any)
+cat tenants/acme/rollback.log
+
+# Wrappers awaiting first-invocation proof (if any)
+cat tenants/acme/.specialist-state.json
+```
+
+---
+
+## 7. Iterate
+
+The customer can teach the agent more by:
+
+1. **Capturing more workflows.** Each `specialist-agent learn` call adds new skills. Existing wrapper skills are reused if synthesis recognizes the endpoint.
+2. **Correcting mid-task.** Saying "also pass `metadata.po_number`" during a `run` triggers `meta.update_skill.update_wrapper`. The change is replay-validated and auto-reverts if the next invocation fails.
+3. **Walking through a new sequence in chat.** Saying "let me show you how to onboard an enterprise customer: first call `stripe.create_customer`, then…" triggers `meta.update_skill.add_workflow`. Pure prose, no replay needed.
+
+All three paths produce git commits with full audit trail. To roll back manually:
+
+```bash
+git -C tenants/acme revert <hash>
+```
+
+---
+
+## Common production tasks
+
+- **Multiple tenants:** create one workspace dir per tenant. Each is a separate git repo with its own skills, services, state, and rollback log.
+- **Production credentials:** never commit them. Use the `SdkEmbeddedProvider` to resolve from your secrets manager at call time.
+- **CI smoke test:** after each `learn`, run `git -C tenants/<id> diff main~1 main -- services/` to review the generated TypeScript before promoting the tenant workspace to production.
+- **Disaster recovery:** the tenant workspace is a regular git repo. Mirror it to a remote and you can rebuild the entire skill set from history.
+
+---
+
+## What can go wrong → see [`TROUBLESHOOTING.md`](./TROUBLESHOOTING.md).

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -20,6 +20,10 @@ async function main() {
 
   const agent = new SpecialistAgent({
     tenant: { id: "demo", workspacePath: tenantPath },
+    // Non-interactive demo: keep every synthesized parameter as-is.
+    // Run via `specialist-agent learn` (without --auto-keep) to exercise
+    // the confirmation prompt.
+    confirmParameter: async () => ({ action: "keep" }),
   });
 
   console.log("\nSynthesizing skills...");

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -1,0 +1,58 @@
+// End-to-end demo: import a HAR trace, synthesize skills, then run the agent.
+//
+//   ANTHROPIC_API_KEY=sk-ant-... npx tsx examples/demo.ts
+//
+// This exercises the full pipeline: scrubbed HAR → synthesis call →
+// wrapper + workflow skills committed to a tenant git repo → agent run.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { SpecialistAgent, importHar } from "../src/index.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function main() {
+  const tenantPath = path.resolve(__dirname, "..", "tenants", "demo");
+  const harFile = path.resolve(__dirname, "stripe-trace.har");
+
+  const trace = await importHar(harFile, "Bill a new customer for Q2 consulting fees");
+  console.log(`Imported HAR trace: ${trace.requests.length} exchanges, intent="${trace.intent}"`);
+
+  const agent = new SpecialistAgent({
+    tenant: { id: "demo", workspacePath: tenantPath },
+  });
+
+  console.log("\nSynthesizing skills...");
+  const result = await agent.learnFromTrace(trace, { skipReplay: false });
+  console.log(`  workflow: ${result.workflow}`);
+  console.log(`  wrappers: ${result.wrappers.join(", ")}`);
+  console.log(`  commit:   ${result.commit.slice(0, 12)}`);
+  console.log(`\nTenant workspace: ${tenantPath}`);
+  console.log("Inspect with: ls .claude/skills/  &&  git -C tenants/demo log --oneline");
+
+  // The agent run is left as an exercise for the reader — running it
+  // requires a STRIPE_API_KEY in the environment because the wrapper
+  // will try to hit real Stripe endpoints. To dry-run the prompt path
+  // without making external calls, comment out the line below or
+  // wire up a mock auth provider.
+  if (process.env.RUN_AGENT === "1") {
+    console.log("\nRunning agent with prompt...");
+    for await (const msg of agent.run(
+      "Bill alice@example.com $500 for April consulting (use 30-day net terms)",
+    )) {
+      if (msg.type === "assistant") {
+        for (const block of msg.message.content) {
+          if (block.type === "text") process.stdout.write(block.text);
+        }
+      }
+    }
+    console.log();
+  } else {
+    console.log("\nSet RUN_AGENT=1 to also exercise agent.run() against the synthesized skills.");
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/examples/proving-check.ts
+++ b/examples/proving-check.ts
@@ -1,0 +1,116 @@
+// Smoke test for the auto-rollback tracker.
+//
+//   npx tsx examples/proving-check.ts
+//
+// Verifies markUnproven/clearUnproven persist correctly, failUnproven
+// reverts and writes to rollback.log, and parseWrapperCommand picks
+// out the wrapper name from the agent's bash invocation strings.
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { TenantWorkspace, SkillRegistry } from "../src/index.js";
+import {
+  clearUnproven,
+  failUnproven,
+  isUnproven,
+  markUnproven,
+  parseWrapperCommand,
+} from "../src/skills/proving.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function assertEqual<T>(label: string, actual: T, expected: T): void {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    console.error(`FAIL ${label}: expected ${e}, got ${a}`);
+    process.exit(1);
+  }
+  console.log(`OK   ${label}`);
+}
+
+async function main() {
+  const tenantPath = path.resolve(__dirname, "..", "tenants", "_proving_check");
+  await fs.rm(tenantPath, { recursive: true, force: true });
+  await fs.mkdir(tenantPath, { recursive: true });
+
+  const ws = new TenantWorkspace({ id: "proving-check", workspacePath: tenantPath });
+  await ws.ensure();
+  const registry = new SkillRegistry(ws);
+
+  // parseWrapperCommand variants
+  assertEqual(
+    "parses npx tsx wrapper.ts form",
+    parseWrapperCommand(
+      "npx tsx /tmp/wrapper.ts stripe create_invoice --customer=cus_1 --tenant=/tmp",
+    ),
+    { wrapperName: "stripe.create_invoice" },
+  );
+  assertEqual(
+    "parses specialist-wrapper form",
+    parseWrapperCommand("specialist-wrapper github create_issue --title=foo"),
+    { wrapperName: "github.create_issue" },
+  );
+  assertEqual(
+    "rejects unrelated bash",
+    parseWrapperCommand("ls -la /tmp"),
+    null,
+  );
+
+  // Mark / read / clear cycle
+  await markUnproven(ws, "stripe.create_invoice", "deadbeef");
+  const entry = await isUnproven(ws, "stripe.create_invoice");
+  if (!entry || entry.commit !== "deadbeef") {
+    console.error("FAIL markUnproven did not persist");
+    process.exit(1);
+  }
+  console.log("OK   markUnproven persisted");
+
+  await clearUnproven(ws, "stripe.create_invoice");
+  const cleared = await isUnproven(ws, "stripe.create_invoice");
+  assertEqual("clearUnproven removes entry", cleared, null);
+
+  // failUnproven: mark, then commit a real change so revert has something
+  // to undo, then trigger fail and confirm the working tree is back to pre-mark
+  // state with a rollback.log entry.
+  await ws.safeFs.writeFile(
+    path.join(ws.servicesDir, "demo.ts"),
+    "// before\n",
+  );
+  await registry.commit({
+    trigger: "synthesis",
+    actor: "agent",
+    message: "before",
+  });
+  await ws.safeFs.writeFile(
+    path.join(ws.servicesDir, "demo.ts"),
+    "// after\n",
+  );
+  const updateCommit = await registry.commit({
+    trigger: "user-instruction",
+    actor: "agent",
+    message: "after",
+  });
+  await markUnproven(ws, "demo.update", updateCommit);
+
+  await failUnproven(ws, "demo.update", registry, "simulated 500");
+
+  const onDisk = await fs.readFile(path.join(ws.servicesDir, "demo.ts"), "utf8");
+  assertEqual("failUnproven reverted file content", onDisk, "// before\n");
+  const log = await fs.readFile(ws.rollbackLog, "utf8");
+  if (!log.includes("demo.update") || !log.includes("simulated 500")) {
+    console.error(`FAIL rollback.log missing entry. Got: ${log}`);
+    process.exit(1);
+  }
+  console.log("OK   rollback.log appended");
+  const after = await isUnproven(ws, "demo.update");
+  assertEqual("failUnproven cleared mark", after, null);
+
+  console.log("\nAll proving assertions passed.");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/examples/safefs-check.ts
+++ b/examples/safefs-check.ts
@@ -1,0 +1,83 @@
+// SafeFs scope-rejection smoke test.
+//
+//   npx tsx examples/safefs-check.ts
+//
+// Constructs a SafeFs against a temp tenant and confirms that writes
+// outside the allowlist throw ScopeViolationError. No network calls.
+
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { TenantWorkspace, ScopeViolationError } from "../src/index.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function expectViolation(label: string, fn: () => Promise<unknown>): Promise<void> {
+  try {
+    await fn();
+    console.error(`FAIL: ${label} — expected ScopeViolationError`);
+    process.exit(1);
+  } catch (e) {
+    if (e instanceof ScopeViolationError) {
+      console.log(`OK   ${label} — rejected: ${e.message}`);
+    } else {
+      console.error(`FAIL: ${label} — got ${(e as Error).name}: ${(e as Error).message}`);
+      process.exit(1);
+    }
+  }
+}
+
+async function expectAllowed(label: string, fn: () => Promise<unknown>): Promise<void> {
+  try {
+    await fn();
+    console.log(`OK   ${label} — allowed`);
+  } catch (e) {
+    console.error(`FAIL: ${label} — unexpected ${(e as Error).name}: ${(e as Error).message}`);
+    process.exit(1);
+  }
+}
+
+async function main() {
+  const tenantPath = path.resolve(__dirname, "..", "tenants", "_safefs_check");
+  await fs.rm(tenantPath, { recursive: true, force: true });
+  await fs.mkdir(tenantPath, { recursive: true });
+
+  const ws = new TenantWorkspace({ id: "safefs-check", workspacePath: tenantPath });
+  const sfs = ws.safeFs;
+
+  // Outside the workspace entirely.
+  await expectViolation("write absolute path outside root", () =>
+    sfs.writeFile("/etc/passwd-evil", "x"),
+  );
+
+  // Path traversal via .. should resolve to a path outside the workspace.
+  await expectViolation("write via .. traversal", () =>
+    sfs.writeFile(path.join(tenantPath, "services", "..", "..", "..", "evil"), "x"),
+  );
+
+  // Inside workspace but outside allowlist (e.g. a sibling of services/).
+  await expectViolation("write to non-allowlisted dir", () =>
+    sfs.writeFile(path.join(tenantPath, "secrets", "leak"), "x"),
+  );
+
+  // Allowlisted writes succeed.
+  await expectAllowed("write skill SKILL.md", () =>
+    sfs.writeFile(path.join(tenantPath, ".claude", "skills", "demo", "SKILL.md"), "ok"),
+  );
+  await expectAllowed("write services file", () =>
+    sfs.writeFile(path.join(tenantPath, "services", "demo.ts"), "// ok"),
+  );
+  await expectAllowed("write state file", () =>
+    sfs.writeFile(ws.stateFile, "{}"),
+  );
+  await expectAllowed("write rollback log", () =>
+    sfs.writeFile(ws.rollbackLog, "log entry\n"),
+  );
+
+  console.log("\nAll SafeFs assertions passed.");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/examples/stripe-trace.har
+++ b/examples/stripe-trace.har
@@ -1,0 +1,104 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": { "name": "demo-fixture", "version": "0.1" },
+    "entries": [
+      {
+        "startedDateTime": "2026-04-29T14:00:00.000Z",
+        "time": 412,
+        "request": {
+          "method": "POST",
+          "url": "https://api.stripe.com/v1/customers",
+          "headers": [
+            { "name": "authorization", "value": "Bearer sk_test_REDACTED" },
+            { "name": "content-type", "value": "application/x-www-form-urlencoded" }
+          ],
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "text": "email=alice%40example.com&name=Alice%20Johnson"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": [{ "name": "content-type", "value": "application/json" }],
+          "content": {
+            "mimeType": "application/json",
+            "text": "{\"id\":\"cus_NeKx5tPv9aBcDe\",\"object\":\"customer\",\"email\":\"alice@example.com\",\"name\":\"Alice Johnson\",\"created\":1714400400}"
+          }
+        }
+      },
+      {
+        "startedDateTime": "2026-04-29T14:00:00.500Z",
+        "time": 387,
+        "request": {
+          "method": "POST",
+          "url": "https://api.stripe.com/v1/invoices",
+          "headers": [
+            { "name": "authorization", "value": "Bearer sk_test_REDACTED" },
+            { "name": "content-type", "value": "application/x-www-form-urlencoded" }
+          ],
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "text": "customer=cus_NeKx5tPv9aBcDe&collection_method=send_invoice&days_until_due=30&description=Q2%20consulting%20fees"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": [{ "name": "content-type", "value": "application/json" }],
+          "content": {
+            "mimeType": "application/json",
+            "text": "{\"id\":\"in_1OxYz2K3LmNoPq\",\"object\":\"invoice\",\"customer\":\"cus_NeKx5tPv9aBcDe\",\"status\":\"draft\",\"amount_due\":0,\"currency\":\"usd\",\"description\":\"Q2 consulting fees\",\"collection_method\":\"send_invoice\"}"
+          }
+        }
+      },
+      {
+        "startedDateTime": "2026-04-29T14:00:01.000Z",
+        "time": 295,
+        "request": {
+          "method": "POST",
+          "url": "https://api.stripe.com/v1/invoiceitems",
+          "headers": [
+            { "name": "authorization", "value": "Bearer sk_test_REDACTED" },
+            { "name": "content-type", "value": "application/x-www-form-urlencoded" }
+          ],
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "text": "customer=cus_NeKx5tPv9aBcDe&invoice=in_1OxYz2K3LmNoPq&amount=50000&currency=usd&description=April%20retainer"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": [{ "name": "content-type", "value": "application/json" }],
+          "content": {
+            "mimeType": "application/json",
+            "text": "{\"id\":\"ii_1OxYz3K3LmNoPq\",\"object\":\"invoiceitem\",\"customer\":\"cus_NeKx5tPv9aBcDe\",\"invoice\":\"in_1OxYz2K3LmNoPq\",\"amount\":50000,\"currency\":\"usd\",\"description\":\"April retainer\"}"
+          }
+        }
+      },
+      {
+        "startedDateTime": "2026-04-29T14:00:01.500Z",
+        "time": 478,
+        "request": {
+          "method": "POST",
+          "url": "https://api.stripe.com/v1/invoices/in_1OxYz2K3LmNoPq/finalize",
+          "headers": [
+            { "name": "authorization", "value": "Bearer sk_test_REDACTED" },
+            { "name": "content-type", "value": "application/x-www-form-urlencoded" }
+          ],
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "text": "auto_advance=true"
+          }
+        },
+        "response": {
+          "status": 200,
+          "headers": [{ "name": "content-type", "value": "application/json" }],
+          "content": {
+            "mimeType": "application/json",
+            "text": "{\"id\":\"in_1OxYz2K3LmNoPq\",\"object\":\"invoice\",\"customer\":\"cus_NeKx5tPv9aBcDe\",\"status\":\"open\",\"amount_due\":50000,\"currency\":\"usd\",\"hosted_invoice_url\":\"https://invoice.stripe.com/i/acct_redacted/invst_redacted\"}"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1336 @@
+{
+  "name": "specialist-agent",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "specialist-agent",
+      "version": "0.1.0",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.1.13",
+        "@anthropic-ai/sdk": "^0.40.0",
+        "zod": "^3.23.8"
+      },
+      "bin": {
+        "specialist-agent": "dist/cli/main.js",
+        "specialist-wrapper": "dist/cli/wrapper.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.1.77.tgz",
+      "integrity": "sha512-ZEjWQtkoB2MEY6K16DWMmF+8OhywAynH0m08V265cerbZ8xPD/2Ng2jPzbbO40mPeFSsMDJboShL+a3aObP0Jg==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.33.5",
+        "@img/sharp-darwin-x64": "^0.33.5",
+        "@img/sharp-linux-arm": "^0.33.5",
+        "@img/sharp-linux-arm64": "^0.33.5",
+        "@img/sharp-linux-x64": "^0.33.5",
+        "@img/sharp-linuxmusl-arm64": "^0.33.5",
+        "@img/sharp-linuxmusl-x64": "^0.33.5",
+        "@img/sharp-win32-x64": "^0.33.5"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.40.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.40.1.tgz",
+      "integrity": "sha512-DJMWm8lTEM9Lk/MSFL+V+ugF7jKOn0M2Ujvb5fN8r2nY14aHbGPZ1k6sgjL+tpJ3VuOGJNG+4R83jEpOuYPv8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "specialist-agent",
+  "version": "0.1.0",
+  "description": "A learning agent built on the Claude Agent SDK that observes customer workflows once and replays them as skills.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "specialist-agent": "./dist/cli/main.js",
+    "specialist-wrapper": "./dist/cli/wrapper.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "agent": "tsx src/cli/main.ts",
+    "wrapper": "tsx src/cli/wrapper.ts",
+    "demo": "tsx examples/demo.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.1.13",
+    "@anthropic-ai/sdk": "^0.40.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,0 +1,217 @@
+import { query, type SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import path from "node:path";
+import { TenantWorkspace } from "./tenant/workspace.js";
+import { createMetaSkillServer } from "./skills/meta.js";
+import { SkillRegistry } from "./skills/registry.js";
+import { synthesizeFromTrace } from "./synthesis/synthesize.js";
+import type { CommitContext, HttpTrace, TenantConfig } from "./types.js";
+import { replayWrapper } from "./execution/replay.js";
+
+/**
+ * Per-tenant agent runtime. Wraps the Claude Agent SDK's `query()` and
+ * wires up:
+ *   - the tenant's skill directory (loaded via settingSources: ["project"])
+ *   - the meta.update_skill MCP server (so the agent can edit its own skills)
+ *   - a Bash allowlist scoped to the wrapper CLI
+ *
+ * The architecture doc calls this "the agent runtime" — one isolated
+ * instance per tenant, skills discovered at task time.
+ */
+export interface SpecialistAgentOptions {
+  tenant: TenantConfig;
+  /**
+   * Confirmation hook for user-instructed skill changes. Defaults to
+   * auto-approve in non-interactive contexts; the CLI overrides this.
+   */
+  confirmInstructedChange?: (summary: string) => Promise<boolean>;
+  /** Override the model used by the runtime. Defaults to the SDK default. */
+  model?: string;
+}
+
+export class SpecialistAgent {
+  readonly workspace: TenantWorkspace;
+  readonly registry: SkillRegistry;
+
+  constructor(private opts: SpecialistAgentOptions) {
+    this.workspace = new TenantWorkspace(opts.tenant);
+    this.registry = new SkillRegistry(this.workspace);
+  }
+
+  async init(): Promise<void> {
+    await this.workspace.ensure();
+  }
+
+  /**
+   * Run a one-shot prompt against the tenant's skills. Yields SDK
+   * messages so the host can stream output.
+   */
+  async *run(prompt: string): AsyncGenerator<SDKMessage, void> {
+    await this.init();
+
+    const meta = createMetaSkillServer({
+      workspace: this.workspace,
+      confirmInstructedChange: this.opts.confirmInstructedChange,
+    });
+
+    const wrapperCli = path.resolve(
+      // The CLI lives next to this file at compile time; tsx resolves the .ts source.
+      new URL(".", import.meta.url).pathname,
+      "cli",
+      "wrapper.ts",
+    );
+
+    for await (const msg of query({
+      prompt,
+      options: {
+        cwd: this.workspace.root,
+        ...(this.opts.model ? { model: this.opts.model } : {}),
+        settingSources: ["project"],
+        // Skills load from .claude/skills/<name>/SKILL.md inside cwd.
+        // Bash + the meta MCP server give the agent everything it needs.
+        allowedTools: [
+          "Skill",
+          "Read",
+          "Glob",
+          "Grep",
+          "Bash",
+          "mcp__specialist-meta__reactive_fix",
+          "mcp__specialist-meta__update_wrapper",
+          "mcp__specialist-meta__add_workflow",
+        ],
+        mcpServers: {
+          "specialist-meta": meta,
+        },
+        systemPrompt: {
+          type: "preset",
+          preset: "claude_code",
+          append: this.systemPromptAppendix(wrapperCli),
+        },
+        // Don't let runaway loops burn the budget on a single user turn.
+        maxTurns: 25,
+      },
+    })) {
+      yield msg;
+    }
+  }
+
+  /**
+   * Synthesize a new workflow from a captured HTTP trace, validate
+   * each generated wrapper, and commit. Returns the names that were
+   * added (or updated).
+   */
+  async learnFromTrace(trace: HttpTrace, opts: { skipReplay?: boolean } = {}): Promise<{
+    workflow: string;
+    wrappers: string[];
+    commit: string;
+  }> {
+    await this.init();
+
+    const existing = await this.listExistingWrappers();
+    const result = await synthesizeFromTrace({
+      trace,
+      existingWrappers: existing,
+    });
+
+    const branch = `synth/${result.workflow.name}-${Date.now()}`;
+    await this.registry.checkoutBranch(branch);
+    const written = await this.registry.writeSynthesisResult(result);
+
+    // Replay each new wrapper. If replay can't be live (no API keys, no
+    // staging), the caller can pass skipReplay and validation defers.
+    const failures: string[] = [];
+    if (!opts.skipReplay) {
+      for (const w of result.wrappers) {
+        const replayArgs = pickReplayArgs(w.spec);
+        const r = await replayWrapper({
+          workspace: this.workspace,
+          spec: w.spec,
+          testArgs: replayArgs,
+          // Default to dry-run unless explicit replay args fully populate
+          // every required parameter. Live replay belongs in a staging
+          // pipeline the host owns.
+          dryRun: true,
+        });
+        if (!r.success) failures.push(`${w.spec.name}: ${r.error}`);
+      }
+    }
+
+    const ctx: CommitContext = {
+      trigger: "synthesis",
+      actor: "agent",
+      message: `synth: ${result.workflow.name} (${result.wrappers.length} wrapper${result.wrappers.length === 1 ? "" : "s"}) — ${trace.intent}`,
+      validation: opts.skipReplay
+        ? undefined
+        : { replayed: true, success: failures.length === 0, notes: failures.join("; ") || undefined },
+    };
+    const commit = await this.registry.commit(ctx);
+
+    if (failures.length === 0) {
+      await this.registry.mergeToMain(branch);
+    }
+
+    return { workflow: written.workflow, wrappers: written.wrappers, commit };
+  }
+
+  private async listExistingWrappers(): Promise<Array<{ name: string; description: string }>> {
+    const names = await this.workspace.listSkillNames();
+    const out: Array<{ name: string; description: string }> = [];
+    for (const name of names) {
+      const skill = await this.registry.readSkill(name);
+      if (!skill) continue;
+      if ((skill.metadata.kind ?? "wrapper") !== "wrapper") continue;
+      out.push({
+        name,
+        description: skill.metadata.description ?? "",
+      });
+    }
+    return out;
+  }
+
+  private systemPromptAppendix(wrapperCli: string): string {
+    return [
+      "You are a specialist agent that has learned this customer's workflows from observed HTTP traces.",
+      "Your skills come from two layers:",
+      "  - Layer 1 wrappers (kind: wrapper): one per HTTP endpoint. Invoke via shell with the specialist-wrapper CLI.",
+      "  - Layer 2 workflows (kind: workflow): pure prose describing how to compose wrappers.",
+      "",
+      "When you receive a task:",
+      "  1. Use the Skill tool to discover relevant skills. Prefer a workflow if one matches; otherwise use wrappers directly.",
+      "  2. For each step, identify the right wrapper, extract arguments from the prompt or prior step responses, and shell out:",
+      `       npx tsx ${wrapperCli} <vendor> <function> --arg=value --tenant=<workspace-root>`,
+      "     The wrapper outputs JSON on stdout. Parse it before extracting values for the next step.",
+      "  3. If a wrapper call fails or returns an unexpected shape, load the wrapper's SKILL.md, the failed request/response, and prior successful steps, then re-reason.",
+      "     If the failure looks like persistent API drift (not transient), invoke `meta.update_skill.reactive_fix` to fix the wrapper for future runs. Validate via replay before merge.",
+      "  4. If the user instructs you to change a skill mid-task ('also pass X', 'use the v2 endpoint now'), use `meta.update_skill.update_wrapper` and confirm the summary with the user before applying.",
+      "  5. If the user walks you through a new sequence in conversation, use `meta.update_skill.add_workflow` to capture it permanently.",
+      "",
+      "Rules:",
+      "  - Never edit files under services/ or .claude/skills/ directly with Edit/Write — always go through the meta tools so changes are validated and committed.",
+      "  - Never read files outside the tenant workspace.",
+      "  - Be terse. The user sees your text output but not your tool calls.",
+    ].join("\n");
+  }
+}
+
+function pickReplayArgs(spec: { parameters: Array<{ name: string; type: string; required: boolean }> }): Record<string, unknown> {
+  // Best-effort placeholder values for dry-run validation. Live replay is
+  // the host's responsibility — production deployments wire this to a
+  // staging fixture.
+  const out: Record<string, unknown> = {};
+  for (const p of spec.parameters) {
+    if (!p.required) continue;
+    switch (p.type) {
+      case "string":
+        out[p.name] = "test_value";
+        break;
+      case "number":
+        out[p.name] = 1;
+        break;
+      case "boolean":
+        out[p.name] = false;
+        break;
+      default:
+        out[p.name] = {};
+    }
+  }
+  return out;
+}

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -3,9 +3,17 @@ import path from "node:path";
 import { TenantWorkspace } from "./tenant/workspace.js";
 import { createMetaSkillServer } from "./skills/meta.js";
 import { SkillRegistry } from "./skills/registry.js";
-import { synthesizeFromTrace } from "./synthesis/synthesize.js";
-import type { CommitContext, HttpTrace, TenantConfig } from "./types.js";
+import { applyParameterDecisions, synthesizeFromTrace } from "./synthesis/synthesize.js";
+import type {
+  CommitContext,
+  HttpTrace,
+  ParameterDecision,
+  TenantConfig,
+  WrapperParameter,
+  WrapperSpec,
+} from "./types.js";
 import { replayWrapper } from "./execution/replay.js";
+import { clearUnproven, failUnproven, isUnproven, parseWrapperCommand } from "./skills/proving.js";
 
 /**
  * Per-tenant agent runtime. Wraps the Claude Agent SDK's `query()` and
@@ -24,6 +32,17 @@ export interface SpecialistAgentOptions {
    * auto-approve in non-interactive contexts; the CLI overrides this.
    */
   confirmInstructedChange?: (summary: string) => Promise<boolean>;
+  /**
+   * Per-parameter confirmation hook that drives the spec's
+   * "Is `"USD"` a wrapper input or a constant?" pass. Called once per
+   * parameter on every newly synthesized wrapper. Default: keep all
+   * (preserves current behavior for non-interactive callers).
+   */
+  confirmParameter?: (ctx: {
+    wrapper: WrapperSpec;
+    parameter: WrapperParameter;
+    observedValue: unknown;
+  }) => Promise<ParameterDecision>;
   /** Override the model used by the runtime. Defaults to the SDK default. */
   model?: string;
 }
@@ -86,12 +105,91 @@ export class SpecialistAgent {
           preset: "claude_code",
           append: this.systemPromptAppendix(wrapperCli),
         },
+        hooks: this.buildHooks(),
         // Don't let runaway loops burn the budget on a single user turn.
         maxTurns: 25,
       },
     })) {
       yield msg;
     }
+  }
+
+  /**
+   * Hooks that drive the auto-rollback guardrail. Spec: "If a freshly-merged
+   * skill version fails on its first production invocation, the agent reverts
+   * the commit and falls back to the prior version."
+   *
+   * PostToolUse fires after every Bash invocation (success or non-zero exit).
+   * PostToolUseFailure fires when the tool itself errored (timeout, etc).
+   * For each, we parse the command back to <vendor>.<function>, then either
+   * clear the unproven mark on success or revert on failure.
+   */
+  private buildHooks() {
+    const workspace = this.workspace;
+    const registry = this.registry;
+
+    const onBashFinish = async (
+      command: string,
+      outcome: { success: boolean; reason: string },
+    ) => {
+      const parsed = parseWrapperCommand(command);
+      if (!parsed) return;
+
+      const entry = await isUnproven(workspace, parsed.wrapperName);
+      if (!entry) return;
+
+      if (outcome.success) {
+        await clearUnproven(workspace, parsed.wrapperName);
+      } else {
+        await failUnproven(workspace, parsed.wrapperName, registry, outcome.reason);
+      }
+    };
+
+    return {
+      PostToolUse: [
+        {
+          hooks: [
+            async (input: unknown) => {
+              const i = input as {
+                tool_name?: string;
+                tool_input?: { command?: string };
+                tool_response?: unknown;
+              };
+              if (i.tool_name !== "Bash" || !i.tool_input?.command) {
+                return { continue: true };
+              }
+              const success = !looksLikeBashFailure(i.tool_response);
+              await onBashFinish(i.tool_input.command, {
+                success,
+                reason: success ? "ok" : describeBashFailure(i.tool_response),
+              });
+              return { continue: true };
+            },
+          ],
+        },
+      ],
+      PostToolUseFailure: [
+        {
+          hooks: [
+            async (input: unknown) => {
+              const i = input as {
+                tool_name?: string;
+                tool_input?: { command?: string };
+                error?: string;
+              };
+              if (i.tool_name !== "Bash" || !i.tool_input?.command) {
+                return { continue: true };
+              }
+              await onBashFinish(i.tool_input.command, {
+                success: false,
+                reason: i.error ?? "tool error",
+              });
+              return { continue: true };
+            },
+          ],
+        },
+      ],
+    };
   }
 
   /**
@@ -111,6 +209,28 @@ export class SpecialistAgent {
       trace,
       existingWrappers: existing,
     });
+
+    // Spec: parameter confirmation pass — "Is `"USD"` a wrapper input or a
+    // constant?". Walk every parameter on every new wrapper, ask the host,
+    // and inline frozen values. Default hook keeps all parameters.
+    const confirmParam = this.opts.confirmParameter ?? (async () => ({ action: "keep" }) as ParameterDecision);
+    for (const w of result.wrappers) {
+      const decisions: Record<string, ParameterDecision> = {};
+      for (const param of w.spec.parameters) {
+        decisions[param.name] = await confirmParam({
+          wrapper: w.spec,
+          parameter: param,
+          observedValue: w.observedValues[param.name],
+        });
+      }
+      const applied = applyParameterDecisions({
+        spec: w.spec,
+        implementation: w.implementation,
+        decisions,
+      });
+      w.spec = applied.spec;
+      w.implementation = applied.implementation;
+    }
 
     const branch = `synth/${result.workflow.name}-${Date.now()}`;
     await this.registry.checkoutBranch(branch);
@@ -190,6 +310,40 @@ export class SpecialistAgent {
       "  - Be terse. The user sees your text output but not your tool calls.",
     ].join("\n");
   }
+}
+
+/**
+ * Heuristic: did the Bash tool's response indicate the command failed?
+ *
+ * The Claude Code Bash tool returns its result as text + flags. A non-zero
+ * exit doesn't make the *tool* fail (the command ran), but the output usually
+ * carries a signal we can pick up: `is_error`, an explicit `error` field, or
+ * the wrapper CLI's own "wrapper failed:" prefix on stderr.
+ */
+function looksLikeBashFailure(response: unknown): boolean {
+  if (response == null) return false;
+  if (typeof response === "object") {
+    const r = response as Record<string, unknown>;
+    if (r.is_error === true) return true;
+    if (typeof r.error === "string" && r.error.length > 0) return true;
+    const text = [r.output, r.stdout, r.stderr, r.content]
+      .filter((v): v is string => typeof v === "string")
+      .join("\n");
+    if (text.includes("wrapper failed:")) return true;
+  }
+  if (typeof response === "string" && response.includes("wrapper failed:")) return true;
+  return false;
+}
+
+function describeBashFailure(response: unknown): string {
+  if (response == null) return "(no response)";
+  if (typeof response === "string") return response.slice(0, 500);
+  const r = response as Record<string, unknown>;
+  if (typeof r.error === "string") return r.error.slice(0, 500);
+  const text = [r.stderr, r.output, r.stdout, r.content]
+    .filter((v): v is string => typeof v === "string")
+    .join("\n");
+  return text.slice(0, 500) || "(unknown failure)";
 }
 
 function pickReplayArgs(spec: { parameters: Array<{ name: string; type: string; required: boolean }> }): Record<string, unknown> {

--- a/src/auth/broker.ts
+++ b/src/auth/broker.ts
@@ -1,0 +1,69 @@
+// The auth broker is the only path through which wrappers obtain credentials.
+// Providers are tried in order of preference.
+
+export type AuthScheme = "bearer" | "basic" | "header" | "query";
+
+export interface AuthCredential {
+  scheme: AuthScheme;
+  token: string;
+  /** Header name (e.g. "Authorization", "X-Api-Key") or query param name. */
+  field?: string;
+}
+
+export interface AuthProvider {
+  readonly name: string;
+  /** Can this provider supply credentials for the given vendor? */
+  canHandle(vendor: string): Promise<boolean>;
+  /** Return the credential, or throw if not currently available. */
+  getCredential(vendor: string): Promise<AuthCredential>;
+}
+
+export class AuthBroker {
+  private providers: AuthProvider[] = [];
+
+  register(provider: AuthProvider): this {
+    this.providers.push(provider);
+    return this;
+  }
+
+  async getCredential(vendor: string): Promise<AuthCredential> {
+    for (const provider of this.providers) {
+      if (await provider.canHandle(vendor)) {
+        return provider.getCredential(vendor);
+      }
+    }
+    throw new Error(
+      `No auth provider available for vendor "${vendor}". Registered: ${this.providers.map((p) => p.name).join(", ") || "(none)"}`,
+    );
+  }
+
+  /**
+   * Apply the credential to a fetch request. Mutates `init` in place.
+   * Returns the (possibly modified) URL.
+   */
+  async applyToRequest(
+    vendor: string,
+    url: string,
+    init: { headers: Record<string, string> },
+  ): Promise<string> {
+    const cred = await this.getCredential(vendor);
+    switch (cred.scheme) {
+      case "bearer":
+        init.headers["Authorization"] = `Bearer ${cred.token}`;
+        return url;
+      case "basic":
+        init.headers["Authorization"] = `Basic ${cred.token}`;
+        return url;
+      case "header":
+        if (!cred.field) throw new Error("header scheme requires field name");
+        init.headers[cred.field] = cred.token;
+        return url;
+      case "query": {
+        if (!cred.field) throw new Error("query scheme requires field name");
+        const u = new URL(url);
+        u.searchParams.set(cred.field, cred.token);
+        return u.toString();
+      }
+    }
+  }
+}

--- a/src/auth/providers.ts
+++ b/src/auth/providers.ts
@@ -1,0 +1,95 @@
+import type { AuthCredential, AuthProvider } from "./broker.js";
+
+/**
+ * API key provider. Reads from environment variables of the form
+ * `<VENDOR>_API_KEY` (uppercased). Use the `scheme` option to control
+ * how the credential is applied to outgoing requests.
+ */
+export class ApiKeyProvider implements AuthProvider {
+  readonly name = "api-key";
+
+  constructor(
+    private opts: {
+      /** "bearer" | "header" | "query" — default "bearer" */
+      scheme?: AuthCredential["scheme"];
+      /** Required for "header" / "query" schemes. */
+      field?: string;
+      /** Override env var name; default `<VENDOR>_API_KEY`. */
+      envVar?: (vendor: string) => string;
+    } = {},
+  ) {}
+
+  private envVarFor(vendor: string): string {
+    return this.opts.envVar
+      ? this.opts.envVar(vendor)
+      : `${vendor.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_API_KEY`;
+  }
+
+  async canHandle(vendor: string): Promise<boolean> {
+    return Boolean(process.env[this.envVarFor(vendor)]);
+  }
+
+  async getCredential(vendor: string): Promise<AuthCredential> {
+    const envVar = this.envVarFor(vendor);
+    const token = process.env[envVar];
+    if (!token) {
+      throw new Error(`API key for "${vendor}" not found in env var ${envVar}.`);
+    }
+    return {
+      scheme: this.opts.scheme ?? "bearer",
+      token,
+      field: this.opts.field,
+    };
+  }
+}
+
+/**
+ * SDK-embedded provider. The host application supplies credentials via a
+ * callback; the agent never sees raw secrets at rest.
+ */
+export class SdkEmbeddedProvider implements AuthProvider {
+  readonly name = "sdk-embedded";
+
+  constructor(
+    private resolve: (vendor: string) => Promise<AuthCredential | null>,
+  ) {}
+
+  async canHandle(vendor: string): Promise<boolean> {
+    return (await this.resolve(vendor)) !== null;
+  }
+
+  async getCredential(vendor: string): Promise<AuthCredential> {
+    const cred = await this.resolve(vendor);
+    if (!cred) throw new Error(`SDK callback returned no credential for "${vendor}".`);
+    return cred;
+  }
+}
+
+/**
+ * OAuth provider stub. The full flow (authorize, exchange, refresh) is
+ * out of scope for v1 — this only consumes already-issued tokens stored
+ * by the host. Refresh logic plugs in via `refreshIfExpired`.
+ */
+export class OAuthProvider implements AuthProvider {
+  readonly name = "oauth";
+
+  constructor(
+    private store: {
+      get(vendor: string): Promise<{ accessToken: string; expiresAt?: number } | null>;
+      refreshIfExpired?(vendor: string): Promise<void>;
+    },
+  ) {}
+
+  async canHandle(vendor: string): Promise<boolean> {
+    return (await this.store.get(vendor)) !== null;
+  }
+
+  async getCredential(vendor: string): Promise<AuthCredential> {
+    if (this.store.refreshIfExpired) {
+      await this.store.refreshIfExpired(vendor);
+    }
+    const token = await this.store.get(vendor);
+    if (!token) throw new Error(`No OAuth token for "${vendor}".`);
+    return { scheme: "bearer", token: token.accessToken };
+  }
+}

--- a/src/capture/buffer.ts
+++ b/src/capture/buffer.ts
@@ -1,0 +1,55 @@
+import { randomUUID } from "node:crypto";
+import type { HttpExchange, HttpTrace } from "../types.js";
+import { scrubBody, scrubHeaders } from "./scrub.js";
+
+export interface CaptureSession {
+  id: string;
+  startedAt: string;
+  intent: string;
+  exchanges: HttpExchange[];
+  add(exchange: Omit<HttpExchange, "index">): void;
+  finish(): HttpTrace;
+}
+
+/**
+ * In-memory buffer for HTTP exchanges. The capture layer (SDK
+ * interceptor or HAR importer) feeds exchanges in; the user marks
+ * end of task and we hand back a finalized HttpTrace.
+ *
+ * Auth scrubbing happens here, on the way in — nothing sensitive is
+ * stored in memory beyond the duration of a single request.
+ */
+export function startCapture(intent: string): CaptureSession {
+  const exchanges: HttpExchange[] = [];
+  return {
+    id: randomUUID(),
+    startedAt: new Date().toISOString(),
+    intent,
+    exchanges,
+    add(exchange) {
+      const scrubbed: HttpExchange = {
+        index: exchanges.length,
+        request: {
+          ...exchange.request,
+          headers: scrubHeaders(exchange.request.headers),
+          body: scrubBody(exchange.request.body),
+        },
+        response: {
+          ...exchange.response,
+          headers: scrubHeaders(exchange.response.headers),
+          body: scrubBody(exchange.response.body),
+        },
+      };
+      exchanges.push(scrubbed);
+    },
+    finish(): HttpTrace {
+      return {
+        id: this.id,
+        startedAt: this.startedAt,
+        endedAt: new Date().toISOString(),
+        intent: this.intent,
+        requests: [...exchanges],
+      };
+    },
+  };
+}

--- a/src/capture/har.ts
+++ b/src/capture/har.ts
@@ -1,0 +1,91 @@
+import { promises as fs } from "node:fs";
+import type { HttpTrace } from "../types.js";
+import { startCapture } from "./buffer.js";
+
+/**
+ * Import an HTTP Archive (HAR) file produced by a browser DevTools
+ * export, MITM proxy, or browser-extension capture surface, and turn
+ * it into a scrubbed HttpTrace.
+ *
+ * HAR field reference: http://www.softwareishard.com/blog/har-12-spec/
+ */
+export async function importHar(filePath: string, intent: string): Promise<HttpTrace> {
+  const raw = await fs.readFile(filePath, "utf8");
+  const parsed = JSON.parse(raw) as HarFile;
+  const session = startCapture(intent);
+
+  for (const entry of parsed.log.entries ?? []) {
+    const reqHeaders = harHeadersToObject(entry.request.headers);
+    const respHeaders = harHeadersToObject(entry.response.headers);
+    const reqBody = parseHarPostData(entry.request.postData);
+    const respBody = parseHarContent(entry.response.content);
+
+    session.add({
+      request: {
+        method: entry.request.method.toUpperCase(),
+        url: entry.request.url,
+        headers: reqHeaders,
+        body: reqBody,
+        timestamp: entry.startedDateTime,
+      },
+      response: {
+        status: entry.response.status,
+        headers: respHeaders,
+        body: respBody,
+        durationMs: Math.max(0, entry.time ?? 0),
+      },
+    });
+  }
+
+  return session.finish();
+}
+
+interface HarFile {
+  log: {
+    entries: Array<{
+      startedDateTime: string;
+      time: number;
+      request: {
+        method: string;
+        url: string;
+        headers: Array<{ name: string; value: string }>;
+        postData?: { mimeType?: string; text?: string };
+      };
+      response: {
+        status: number;
+        headers: Array<{ name: string; value: string }>;
+        content?: { mimeType?: string; text?: string };
+      };
+    }>;
+  };
+}
+
+function harHeadersToObject(arr: Array<{ name: string; value: string }>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const h of arr ?? []) out[h.name] = h.value;
+  return out;
+}
+
+function parseHarPostData(pd: { mimeType?: string; text?: string } | undefined): unknown {
+  if (!pd?.text) return null;
+  if (pd.mimeType?.includes("application/json")) {
+    try {
+      return JSON.parse(pd.text);
+    } catch {
+      return pd.text;
+    }
+  }
+  return pd.text;
+}
+
+function parseHarContent(c: { mimeType?: string; text?: string } | undefined): unknown {
+  if (!c?.text) return null;
+  if (c.mimeType?.includes("application/json")) {
+    try {
+      return JSON.parse(c.text);
+    } catch {
+      return c.text;
+    }
+  }
+  return c.text;
+}

--- a/src/capture/interceptor.ts
+++ b/src/capture/interceptor.ts
@@ -1,0 +1,105 @@
+import type { CaptureSession } from "./buffer.js";
+
+/**
+ * SDK interceptor: patches `globalThis.fetch` so every outbound HTTP
+ * call during the capture window lands in the buffer. This is the
+ * "embedded SDK" capture surface from the architecture doc — the
+ * browser-extension and MITM-proxy variants produce HAR data which
+ * is imported through `har.ts`.
+ *
+ * Returns a stop() function. Always call it.
+ */
+export function attachFetchInterceptor(session: CaptureSession): () => void {
+  const original = globalThis.fetch;
+  if (!original) {
+    throw new Error("globalThis.fetch is not available in this runtime.");
+  }
+
+  const patched: typeof fetch = async (input, init) => {
+    const startedAt = Date.now();
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const method = (init?.method ?? (typeof input === "object" && "method" in input ? input.method : "GET")) || "GET";
+    const reqHeaders = headersToObject(init?.headers);
+    const reqBody = await safeReadBody(init?.body);
+
+    let response: Response;
+    let error: unknown;
+    try {
+      response = await original(input as RequestInfo, init);
+    } catch (e) {
+      error = e;
+      throw e;
+    } finally {
+      if (!error) {
+        const duration = Date.now() - startedAt;
+        // Clone the response so the caller still gets a fresh body.
+        const cloned = (response! as Response).clone();
+        const respBody = await safeReadResponseBody(cloned);
+        session.add({
+          request: {
+            method: method.toUpperCase(),
+            url,
+            headers: reqHeaders,
+            body: reqBody,
+            timestamp: new Date(startedAt).toISOString(),
+          },
+          response: {
+            status: response!.status,
+            headers: headersToObject(response!.headers),
+            body: respBody,
+            durationMs: duration,
+          },
+        });
+      }
+    }
+    return response!;
+  };
+
+  globalThis.fetch = patched;
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+function headersToObject(input: HeadersInit | Headers | undefined): Record<string, string> {
+  if (!input) return {};
+  if (input instanceof Headers) {
+    const out: Record<string, string> = {};
+    input.forEach((v, k) => {
+      out[k] = v;
+    });
+    return out;
+  }
+  if (Array.isArray(input)) {
+    return Object.fromEntries(input);
+  }
+  return { ...(input as Record<string, string>) };
+}
+
+async function safeReadBody(body: BodyInit | null | undefined): Promise<unknown> {
+  if (body == null) return null;
+  if (typeof body === "string") return tryJson(body);
+  if (body instanceof URLSearchParams) return Object.fromEntries(body);
+  // For streams, FormData, Blob — capture a marker rather than draining.
+  return `[binary or stream body, type=${(body as { constructor?: { name: string } }).constructor?.name ?? typeof body}]`;
+}
+
+async function safeReadResponseBody(res: Response): Promise<unknown> {
+  const ct = res.headers.get("content-type") ?? "";
+  try {
+    if (ct.includes("application/json")) return await res.json();
+    const text = await res.text();
+    return tryJson(text);
+  } catch {
+    return null;
+  }
+}
+
+function tryJson(s: string): unknown {
+  if (!s) return s;
+  try {
+    return JSON.parse(s);
+  } catch {
+    return s;
+  }
+}

--- a/src/capture/scrub.ts
+++ b/src/capture/scrub.ts
@@ -1,0 +1,61 @@
+// Scrub auth headers and tokens out of captures before they hit storage.
+// We replace recognized auth values with {{auth}} placeholders so the
+// trace remains structurally faithful but no secrets are persisted.
+
+const AUTH_HEADER_NAMES = new Set([
+  "authorization",
+  "x-api-key",
+  "api-key",
+  "x-auth-token",
+  "x-access-token",
+  "cookie",
+  "set-cookie",
+  "proxy-authorization",
+]);
+
+export function scrubHeaders(headers: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    out[k] = AUTH_HEADER_NAMES.has(k.toLowerCase()) ? "{{auth}}" : v;
+  }
+  return out;
+}
+
+/**
+ * Walk an arbitrary JSON-ish body and redact values keyed by anything
+ * that looks like a credential. Cheap and best-effort — synthesis is
+ * the next layer of defense.
+ */
+export function scrubBody(body: unknown): unknown {
+  if (body == null) return body;
+  if (typeof body === "string") {
+    // Strip obvious bearer prefixes embedded in form-encoded payloads.
+    return body.replace(/(Bearer\s+)[A-Za-z0-9._\-]+/gi, "$1{{auth}}");
+  }
+  if (Array.isArray(body)) return body.map(scrubBody);
+  if (typeof body === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(body as Record<string, unknown>)) {
+      if (looksLikeSecretKey(k)) {
+        out[k] = "{{auth}}";
+      } else {
+        out[k] = scrubBody(v);
+      }
+    }
+    return out;
+  }
+  return body;
+}
+
+function looksLikeSecretKey(key: string): boolean {
+  const k = key.toLowerCase();
+  return (
+    k.includes("api_key") ||
+    k.includes("apikey") ||
+    k.includes("access_token") ||
+    k.includes("refresh_token") ||
+    k.includes("client_secret") ||
+    k === "password" ||
+    k === "secret"
+  );
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -14,6 +14,7 @@ import readline from "node:readline";
 import { SpecialistAgent } from "../agent.js";
 import { TenantWorkspace } from "../tenant/workspace.js";
 import { importHar } from "../capture/har.js";
+import type { ParameterDecision } from "../types.js";
 
 interface Flags {
   tenant?: string;
@@ -21,6 +22,8 @@ interface Flags {
   intent?: string;
   model?: string;
   yes?: boolean;
+  /** Skip the parameter-confirmation prompt and keep all parameters. */
+  "auto-keep"?: boolean;
   positional: string[];
 }
 
@@ -48,12 +51,33 @@ async function cmdLearn(flags: Flags): Promise<void> {
   const agent = new SpecialistAgent({
     tenant: { id: path.basename(flags.tenant!), workspacePath: path.resolve(flags.tenant!) },
     ...(flags.model ? { model: flags.model } : {}),
+    confirmParameter: flags["auto-keep"]
+      ? async () => ({ action: "keep" }) as ParameterDecision
+      : async ({ wrapper, parameter, observedValue }) => {
+          const observed = renderObserved(observedValue);
+          console.log(
+            `\n${wrapper.name} — parameter \`${parameter.name}\` (${parameter.type}, ${parameter.required ? "required" : "optional"})`,
+          );
+          console.log(`  observed in trace: ${observed}`);
+          const ans = (await promptText("  [k]eep as parameter / [f]reeze as constant? [k] ")).toLowerCase();
+          if (ans === "f" || ans === "freeze") {
+            return { action: "freeze", constantValue: observedValue };
+          }
+          return { action: "keep" };
+        },
   });
   const result = await agent.learnFromTrace(trace, { skipReplay: false });
 
-  console.log(`Synthesized workflow: ${result.workflow}`);
+  console.log(`\nSynthesized workflow: ${result.workflow}`);
   console.log(`Wrappers: ${result.wrappers.join(", ") || "(none new)"}`);
   if (result.commit) console.log(`Commit: ${result.commit.slice(0, 12)}`);
+}
+
+function renderObserved(value: unknown): string {
+  if (value === undefined) return "(none)";
+  if (value === null) return "null";
+  const s = typeof value === "string" ? JSON.stringify(value) : JSON.stringify(value);
+  return s.length > 200 ? s.slice(0, 200) + "…" : s;
 }
 
 async function cmdRun(flags: Flags): Promise<void> {
@@ -106,6 +130,16 @@ function promptUser(q: string): Promise<boolean> {
   });
 }
 
+function promptText(q: string): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(q, (a) => {
+      rl.close();
+      resolve(a.trim());
+    });
+  });
+}
+
 async function main() {
   const [cmd, ...rest] = process.argv.slice(2);
   const flags = parseFlags(rest);
@@ -118,7 +152,7 @@ async function main() {
       return cmdLog(flags);
     default:
       console.error("usage: specialist-agent <learn|run|log> [flags]");
-      console.error("  learn --tenant=<path> --har=<file> --intent=\"...\"");
+      console.error("  learn --tenant=<path> --har=<file> --intent=\"...\" [--auto-keep]");
       console.error("  run   --tenant=<path> [--yes] \"<prompt>\"");
       console.error("  log   --tenant=<path>");
       process.exit(2);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// Top-level CLI for the specialist agent.
+//
+//   specialist-agent learn  --tenant=<path> --har=<file> --intent="..."
+//   specialist-agent run    --tenant=<path> "<prompt>"
+//   specialist-agent log    --tenant=<path>
+//
+// The "learn" command runs synthesis end-to-end: HAR → skills → commit.
+// The "run" command starts a Claude Agent SDK session against the tenant's
+// skill set. "log" tails the git history of skill changes.
+
+import path from "node:path";
+import readline from "node:readline";
+import { SpecialistAgent } from "../agent.js";
+import { TenantWorkspace } from "../tenant/workspace.js";
+import { importHar } from "../capture/har.js";
+
+interface Flags {
+  tenant?: string;
+  har?: string;
+  intent?: string;
+  model?: string;
+  yes?: boolean;
+  positional: string[];
+}
+
+function parseFlags(argv: string[]): Flags {
+  const f: Flags = { positional: [] };
+  for (const tok of argv) {
+    if (!tok.startsWith("--")) {
+      f.positional.push(tok);
+      continue;
+    }
+    const eq = tok.indexOf("=");
+    const key = tok.slice(2, eq === -1 ? undefined : eq);
+    const val = eq === -1 ? "true" : tok.slice(eq + 1);
+    (f as unknown as Record<string, unknown>)[key] = val === "true" ? true : val;
+  }
+  return f;
+}
+
+async function cmdLearn(flags: Flags): Promise<void> {
+  if (!flags.tenant) die("missing --tenant=<path>");
+  if (!flags.har) die("missing --har=<file> (HAR export from browser DevTools, MITM, or extension)");
+  if (!flags.intent) die("missing --intent=\"<one-sentence task description>\"");
+
+  const trace = await importHar(flags.har!, flags.intent!);
+  const agent = new SpecialistAgent({
+    tenant: { id: path.basename(flags.tenant!), workspacePath: path.resolve(flags.tenant!) },
+    ...(flags.model ? { model: flags.model } : {}),
+  });
+  const result = await agent.learnFromTrace(trace, { skipReplay: false });
+
+  console.log(`Synthesized workflow: ${result.workflow}`);
+  console.log(`Wrappers: ${result.wrappers.join(", ") || "(none new)"}`);
+  if (result.commit) console.log(`Commit: ${result.commit.slice(0, 12)}`);
+}
+
+async function cmdRun(flags: Flags): Promise<void> {
+  if (!flags.tenant) die("missing --tenant=<path>");
+  const prompt = flags.positional.join(" ").trim();
+  if (!prompt) die("usage: specialist-agent run --tenant=<path> \"<prompt>\"");
+
+  const agent = new SpecialistAgent({
+    tenant: { id: path.basename(flags.tenant!), workspacePath: path.resolve(flags.tenant!) },
+    ...(flags.model ? { model: flags.model } : {}),
+    confirmInstructedChange: flags.yes
+      ? async () => true
+      : async (summary) => promptUser(`The agent wants to apply: "${summary}". Confirm? [y/N] `),
+  });
+
+  for await (const msg of agent.run(prompt)) {
+    if (msg.type === "assistant") {
+      for (const block of msg.message.content) {
+        if (block.type === "text") process.stdout.write(block.text);
+      }
+    } else if (msg.type === "result") {
+      process.stdout.write(`\n\n[done — cost $${msg.total_cost_usd.toFixed(4)}, turns ${msg.num_turns}]\n`);
+    }
+  }
+}
+
+async function cmdLog(flags: Flags): Promise<void> {
+  if (!flags.tenant) die("missing --tenant=<path>");
+  const ws = new TenantWorkspace({
+    id: path.basename(flags.tenant!),
+    workspacePath: path.resolve(flags.tenant!),
+  });
+  await ws.ensure();
+  const { stdout } = await ws.git("log", "--pretty=format:%h  %s%n  %b", "-n", "30");
+  process.stdout.write(stdout + "\n");
+}
+
+function die(msg: string): never {
+  console.error(`error: ${msg}`);
+  process.exit(2);
+}
+
+function promptUser(q: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(q, (a) => {
+      rl.close();
+      resolve(/^y(es)?$/i.test(a.trim()));
+    });
+  });
+}
+
+async function main() {
+  const [cmd, ...rest] = process.argv.slice(2);
+  const flags = parseFlags(rest);
+  switch (cmd) {
+    case "learn":
+      return cmdLearn(flags);
+    case "run":
+      return cmdRun(flags);
+    case "log":
+      return cmdLog(flags);
+    default:
+      console.error("usage: specialist-agent <learn|run|log> [flags]");
+      console.error("  learn --tenant=<path> --har=<file> --intent=\"...\"");
+      console.error("  run   --tenant=<path> [--yes] \"<prompt>\"");
+      console.error("  log   --tenant=<path>");
+      process.exit(2);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/cli/wrapper.ts
+++ b/src/cli/wrapper.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Invoke a generated wrapper function from the shell.
+//
+//   specialist-wrapper <vendor> <function> [--key=value ...]
+//
+// The agent's runtime turns each step of a workflow skill into one of
+// these calls. The output is JSON on stdout; non-zero exit + diagnostics
+// on stderr.
+
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+async function main() {
+  const argv = process.argv.slice(2);
+  if (argv.length < 2) {
+    console.error(
+      "usage: specialist-wrapper <vendor> <function> [--key=value ...] [--tenant=path/to/tenant]",
+    );
+    process.exit(2);
+  }
+
+  const vendor = argv[0]!;
+  const fnName = argv[1]!;
+  const positional = argv.slice(2);
+
+  let tenantPath = process.env.SPECIALIST_TENANT_PATH;
+  const args: Record<string, unknown> = {};
+
+  for (const tok of positional) {
+    if (!tok.startsWith("--")) continue;
+    const eq = tok.indexOf("=");
+    const key = tok.slice(2, eq === -1 ? undefined : eq);
+    const raw = eq === -1 ? "true" : tok.slice(eq + 1);
+    if (key === "tenant") {
+      tenantPath = raw;
+      continue;
+    }
+    args[key] = coerce(raw);
+  }
+
+  if (!tenantPath) {
+    console.error(
+      "no tenant workspace specified — pass --tenant=<path> or set SPECIALIST_TENANT_PATH",
+    );
+    process.exit(2);
+  }
+
+  const file = path.resolve(tenantPath, "services", `${vendor}.ts`);
+  const url = pathToFileURL(file).href;
+
+  let mod: Record<string, unknown>;
+  try {
+    mod = (await import(url)) as Record<string, unknown>;
+  } catch (e) {
+    console.error(`failed to load ${file}: ${(e as Error).message}`);
+    process.exit(1);
+  }
+
+  const fn = mod[fnName];
+  if (typeof fn !== "function") {
+    console.error(`function "${fnName}" not exported from ${file}`);
+    console.error(`exports: ${Object.keys(mod).join(", ") || "(none)"}`);
+    process.exit(1);
+  }
+
+  try {
+    const result = await (fn as (a: unknown) => Promise<unknown>)(args);
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  } catch (e) {
+    const err = e as Error & { status?: number; body?: unknown };
+    console.error(`wrapper failed: ${err.message}`);
+    if (err.status) console.error(`status: ${err.status}`);
+    if (err.body !== undefined) {
+      console.error(`body: ${typeof err.body === "string" ? err.body : JSON.stringify(err.body)}`);
+    }
+    process.exit(1);
+  }
+}
+
+function coerce(raw: string): unknown {
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  if (raw === "null") return null;
+  if (/^-?\d+(\.\d+)?$/.test(raw)) return Number(raw);
+  if ((raw.startsWith("{") && raw.endsWith("}")) || (raw.startsWith("[") && raw.endsWith("]"))) {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      // fall through
+    }
+  }
+  return raw;
+}
+
+main();

--- a/src/execution/replay.ts
+++ b/src/execution/replay.ts
@@ -1,0 +1,47 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import type { TenantWorkspace } from "../tenant/workspace.js";
+import type { WrapperSpec } from "../types.js";
+
+/**
+ * Replay a freshly synthesized wrapper against the live (or staging)
+ * endpoint to confirm it works. The architecture doc treats this as
+ * a gate before merging a skill change to main.
+ *
+ * If `dryRun` is true, we only verify that the function loads and
+ * its signature matches the spec — useful in environments where
+ * making a real call would have side effects.
+ */
+export async function replayWrapper(args: {
+  workspace: TenantWorkspace;
+  spec: WrapperSpec;
+  testArgs: Record<string, unknown>;
+  dryRun?: boolean;
+}): Promise<{ success: boolean; result?: unknown; error?: string }> {
+  const fnName = args.spec.name.split(".").pop() ?? args.spec.name;
+  const file = args.workspace.serviceFile(args.spec.vendor);
+  const absPath = path.resolve(file);
+
+  let mod: Record<string, unknown>;
+  try {
+    // Cache-bust: replay can be called repeatedly during a session.
+    const url = `${pathToFileURL(absPath).href}?t=${Date.now()}`;
+    mod = (await import(url)) as Record<string, unknown>;
+  } catch (e) {
+    return { success: false, error: `failed to load ${file}: ${(e as Error).message}` };
+  }
+
+  const fn = mod[fnName];
+  if (typeof fn !== "function") {
+    return { success: false, error: `function "${fnName}" not exported from ${file}` };
+  }
+
+  if (args.dryRun) return { success: true };
+
+  try {
+    const result = await (fn as (a: unknown) => Promise<unknown>)(args.testArgs);
+    return { success: true, result };
+  } catch (e) {
+    return { success: false, error: (e as Error).message };
+  }
+}

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -1,0 +1,97 @@
+import { AuthBroker } from "../auth/broker.js";
+import { ApiKeyProvider, SdkEmbeddedProvider } from "../auth/providers.js";
+
+/**
+ * Helper used by every generated wrapper function. Builds a fetch
+ * request, injects auth via the AuthBroker, sends it, and returns
+ * the parsed body. Failures throw with the response status and body.
+ *
+ * This is the only HTTP touchpoint for wrappers — keeping wrappers
+ * thin in exactly one place.
+ */
+export interface RunWrapperOptions {
+  vendor: string;
+  method: string;
+  url: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+  /** Inject auth — defaults to true. Set false for endpoints that don't need it. */
+  auth?: boolean;
+}
+
+export async function runWrapper(opts: RunWrapperOptions): Promise<unknown> {
+  const broker = getDefaultBroker();
+  const headers: Record<string, string> = {
+    "content-type": opts.body ? "application/json" : "application/x-www-form-urlencoded",
+    accept: "application/json",
+    ...(opts.headers ?? {}),
+  };
+
+  let url = opts.url;
+  if (opts.auth !== false) {
+    url = await broker.applyToRequest(opts.vendor, url, { headers });
+  }
+
+  const init: RequestInit = {
+    method: opts.method.toUpperCase(),
+    headers,
+  };
+  if (opts.body !== undefined) {
+    init.body = typeof opts.body === "string" ? opts.body : JSON.stringify(opts.body);
+  }
+
+  const response = await fetch(url, init);
+  const text = await response.text();
+  let parsed: unknown = text;
+  if (text && response.headers.get("content-type")?.includes("application/json")) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      // Leave as raw text — wrapper caller can decide what to do.
+    }
+  }
+
+  if (!response.ok) {
+    const err = new WrapperHttpError(
+      `${opts.method.toUpperCase()} ${opts.url} — ${response.status} ${response.statusText}`,
+      response.status,
+      parsed,
+    );
+    throw err;
+  }
+
+  return parsed;
+}
+
+export class WrapperHttpError extends Error {
+  constructor(
+    message: string,
+    public status: number,
+    public body: unknown,
+  ) {
+    super(message);
+    this.name = "WrapperHttpError";
+  }
+}
+
+/**
+ * The default broker is wired up from environment variables. Hosts
+ * embedding the agent (the "SDK-embedded" path from the architecture
+ * doc) can override this via `setDefaultBroker`.
+ */
+let _broker: AuthBroker | undefined;
+
+export function setDefaultBroker(broker: AuthBroker): void {
+  _broker = broker;
+}
+
+export function getDefaultBroker(): AuthBroker {
+  if (!_broker) {
+    _broker = new AuthBroker()
+      .register(new ApiKeyProvider({ scheme: "bearer" }))
+      .register(
+        new SdkEmbeddedProvider(async () => null), // host can replace this
+      );
+  }
+  return _broker;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export type { SpecialistAgentOptions } from "./agent.js";
 export { TenantWorkspace } from "./tenant/workspace.js";
 export { SkillRegistry } from "./skills/registry.js";
 export { createMetaSkillServer } from "./skills/meta.js";
+export { SafeFs, ScopeViolationError } from "./skills/safe-fs.js";
 
 export { AuthBroker } from "./auth/broker.js";
 export type { AuthCredential, AuthProvider, AuthScheme } from "./auth/broker.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,36 @@
+// Public surface of the specialist-agent package.
+
+export { SpecialistAgent } from "./agent.js";
+export type { SpecialistAgentOptions } from "./agent.js";
+
+export { TenantWorkspace } from "./tenant/workspace.js";
+export { SkillRegistry } from "./skills/registry.js";
+export { createMetaSkillServer } from "./skills/meta.js";
+
+export { AuthBroker } from "./auth/broker.js";
+export type { AuthCredential, AuthProvider, AuthScheme } from "./auth/broker.js";
+export { ApiKeyProvider, OAuthProvider, SdkEmbeddedProvider } from "./auth/providers.js";
+
+export { runWrapper, setDefaultBroker, getDefaultBroker, WrapperHttpError } from "./execution/runner.js";
+export { replayWrapper } from "./execution/replay.js";
+
+export { startCapture } from "./capture/buffer.js";
+export type { CaptureSession } from "./capture/buffer.js";
+export { attachFetchInterceptor } from "./capture/interceptor.js";
+export { importHar } from "./capture/har.js";
+export { scrubBody, scrubHeaders } from "./capture/scrub.js";
+
+export { synthesizeFromTrace } from "./synthesis/synthesize.js";
+
+export type {
+  CommitContext,
+  HttpExchange,
+  HttpTrace,
+  SkillKind,
+  SkillMetadata,
+  SynthesisResult,
+  TenantConfig,
+  WorkflowSpec,
+  WrapperParameter,
+  WrapperSpec,
+} from "./types.js";

--- a/src/skills/meta.ts
+++ b/src/skills/meta.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { TenantWorkspace } from "../tenant/workspace.js";
 import { SkillRegistry } from "./registry.js";
 import { replayWrapper } from "../execution/replay.js";
+import { markUnproven } from "./proving.js";
 import type { CommitContext, WrapperSpec } from "../types.js";
 
 /**
@@ -12,8 +13,14 @@ import type { CommitContext, WrapperSpec } from "../types.js";
  *   - update_wrapper: requires user confirmation; the agent shows a summary
  *   - add_workflow: assembles a new workflow from conversation
  *
- * Scope limit: these tools can ONLY edit files inside the tenant workspace.
- * The auth broker, runtime, and the meta server itself are off-limits.
+ * Scope limit: these tools never bypass `workspace.safeFs`. All writes go
+ * through SkillRegistry, which uses SafeFs under the hood. The auth broker,
+ * runtime, and the meta server itself are off-limits — enforced by the
+ * SafeFs allowlist, not just convention.
+ *
+ * Auto-rollback: after a successful merge, reactive_fix and update_wrapper
+ * both call `markUnproven`. The agent's PostToolUse hook reverts the merge
+ * if the wrapper fails on its first invocation.
  */
 export function createMetaSkillServer(args: {
   workspace: TenantWorkspace;
@@ -82,7 +89,7 @@ export function createMetaSkillServer(args: {
         message: `meta: reactive fix for ${input.wrapperName} — ${input.diffSummary}`,
         validation: { replayed: true, success: replay.success, notes: replay.error },
       };
-      await registry.commit(ctx);
+      const commit = await registry.commit(ctx);
 
       if (!replay.success) {
         return {
@@ -97,11 +104,12 @@ export function createMetaSkillServer(args: {
       }
 
       await registry.mergeToMain(branch);
+      await markUnproven(args.workspace, input.wrapperName, commit);
       return {
         content: [
           {
             type: "text" as const,
-            text: `Reactive fix applied: ${input.wrapperName} updated, replayed, and merged to main.`,
+            text: `Reactive fix applied: ${input.wrapperName} updated, replayed, and merged to main. Marked unproven — auto-revert if first invocation fails.`,
           },
         ],
       };
@@ -157,7 +165,7 @@ export function createMetaSkillServer(args: {
         testArgs: input.replayArgs,
       });
 
-      await registry.commit({
+      const commit = await registry.commit({
         trigger: "user-instruction",
         actor: "agent",
         message: `meta: ${input.summary}`,
@@ -177,9 +185,13 @@ export function createMetaSkillServer(args: {
       }
 
       await registry.mergeToMain(branch);
+      await markUnproven(args.workspace, input.wrapperName, commit);
       return {
         content: [
-          { type: "text" as const, text: `Wrapper ${input.wrapperName} updated, replayed, and merged.` },
+          {
+            type: "text" as const,
+            text: `Wrapper ${input.wrapperName} updated, replayed, and merged. Marked unproven — auto-revert if first invocation fails.`,
+          },
         ],
       };
     },

--- a/src/skills/meta.ts
+++ b/src/skills/meta.ts
@@ -1,0 +1,235 @@
+import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import type { TenantWorkspace } from "../tenant/workspace.js";
+import { SkillRegistry } from "./registry.js";
+import { replayWrapper } from "../execution/replay.js";
+import type { CommitContext, WrapperSpec } from "../types.js";
+
+/**
+ * The meta.update_skill MCP server gives the agent three tools to modify
+ * its own skill set, with the guardrails described in the architecture doc:
+ *   - reactive_fix: applies automatically (clear failure → drift → fix)
+ *   - update_wrapper: requires user confirmation; the agent shows a summary
+ *   - add_workflow: assembles a new workflow from conversation
+ *
+ * Scope limit: these tools can ONLY edit files inside the tenant workspace.
+ * The auth broker, runtime, and the meta server itself are off-limits.
+ */
+export function createMetaSkillServer(args: {
+  workspace: TenantWorkspace;
+  /**
+   * Hook the host can use to require explicit user confirmation for
+   * user-instructed changes. Return false to abort.
+   */
+  confirmInstructedChange?: (summary: string) => Promise<boolean>;
+}) {
+  const registry = new SkillRegistry(args.workspace);
+  const confirm = args.confirmInstructedChange ?? (async () => true);
+
+  const reactiveFix = tool(
+    "reactive_fix",
+    "Apply a reactive fix to a wrapper skill that just failed with persistent drift. " +
+      "Use this when an API has clearly changed shape (status code, schema, URL) and the failure is not transient. " +
+      "Validates against staging via replay before merging.",
+    {
+      wrapperName: z.string().describe('Wrapper skill name, e.g. "stripe.create_invoice"'),
+      diffSummary: z
+        .string()
+        .describe("One-line summary of what drifted, in past tense (e.g. 'response shape moved invoice_id under .data.id')"),
+      updatedSpec: z
+        .object({
+          name: z.string(),
+          vendor: z.string(),
+          description: z.string(),
+          whenToUse: z.string(),
+          http: z.object({
+            method: z.string(),
+            urlTemplate: z.string(),
+            contentType: z.string(),
+          }),
+          parameters: z.array(
+            z.object({
+              name: z.string(),
+              type: z.enum(["string", "number", "boolean", "object"]),
+              description: z.string(),
+              required: z.boolean(),
+            }),
+          ),
+          returns: z.string(),
+        })
+        .describe("Full updated wrapper spec — replaces the existing one."),
+      updatedImplementation: z
+        .string()
+        .describe("New TypeScript function body (no signature) that calls runWrapper(...)"),
+      replayArgs: z
+        .record(z.unknown())
+        .describe("Concrete arguments to use when replaying the wrapper for validation."),
+    },
+    async (input) => {
+      const branch = `meta/reactive-fix-${input.wrapperName}-${Date.now()}`;
+      await registry.checkoutBranch(branch);
+      await registry.writeWrapper(input.updatedSpec as WrapperSpec, input.updatedImplementation);
+
+      const replay = await replayWrapper({
+        workspace: args.workspace,
+        spec: input.updatedSpec as WrapperSpec,
+        testArgs: input.replayArgs,
+      });
+
+      const ctx: CommitContext = {
+        trigger: "reactive-fix",
+        actor: "agent",
+        message: `meta: reactive fix for ${input.wrapperName} — ${input.diffSummary}`,
+        validation: { replayed: true, success: replay.success, notes: replay.error },
+      };
+      await registry.commit(ctx);
+
+      if (!replay.success) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Reactive fix DID NOT validate. Branch \`${branch}\` retained for review. Error: ${replay.error}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      await registry.mergeToMain(branch);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Reactive fix applied: ${input.wrapperName} updated, replayed, and merged to main.`,
+          },
+        ],
+      };
+    },
+  );
+
+  const updateWrapper = tool(
+    "update_wrapper",
+    "Update a wrapper skill in response to an explicit user instruction (e.g. 'also pass tax_rate', 'this should hit v2 now'). " +
+      "Requires the user to confirm a one-line summary before applying.",
+    {
+      wrapperName: z.string(),
+      summary: z.string().describe("One-line user-facing summary, e.g. 'add tax_rate parameter to stripe.create_invoice'"),
+      updatedSpec: z
+        .object({
+          name: z.string(),
+          vendor: z.string(),
+          description: z.string(),
+          whenToUse: z.string(),
+          http: z.object({
+            method: z.string(),
+            urlTemplate: z.string(),
+            contentType: z.string(),
+          }),
+          parameters: z.array(
+            z.object({
+              name: z.string(),
+              type: z.enum(["string", "number", "boolean", "object"]),
+              description: z.string(),
+              required: z.boolean(),
+            }),
+          ),
+          returns: z.string(),
+        }),
+      updatedImplementation: z.string(),
+      replayArgs: z.record(z.unknown()).describe("Args for staging replay."),
+    },
+    async (input) => {
+      const ok = await confirm(input.summary);
+      if (!ok) {
+        return {
+          content: [{ type: "text" as const, text: "User declined the change; no edit made." }],
+        };
+      }
+
+      const branch = `meta/update-${input.wrapperName}-${Date.now()}`;
+      await registry.checkoutBranch(branch);
+      await registry.writeWrapper(input.updatedSpec as WrapperSpec, input.updatedImplementation);
+
+      const replay = await replayWrapper({
+        workspace: args.workspace,
+        spec: input.updatedSpec as WrapperSpec,
+        testArgs: input.replayArgs,
+      });
+
+      await registry.commit({
+        trigger: "user-instruction",
+        actor: "agent",
+        message: `meta: ${input.summary}`,
+        validation: { replayed: true, success: replay.success, notes: replay.error },
+      });
+
+      if (!replay.success) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Change validated and committed to branch \`${branch}\` but replay FAILED — staying on branch. Error: ${replay.error}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      await registry.mergeToMain(branch);
+      return {
+        content: [
+          { type: "text" as const, text: `Wrapper ${input.wrapperName} updated, replayed, and merged.` },
+        ],
+      };
+    },
+  );
+
+  const addWorkflow = tool(
+    "add_workflow",
+    "Add a new workflow skill assembled from conversation (the user walked the agent through a sequence in chat without turning on capture). " +
+      "Pure markdown — no replay needed. Still requires user confirmation.",
+    {
+      summary: z.string().describe("One-line description of the workflow being added."),
+      workflow: z.object({
+        name: z.string(),
+        description: z.string(),
+        whenToUse: z.string(),
+        steps: z.array(z.string()),
+        inputs: z.array(
+          z.object({
+            name: z.string(),
+            type: z.enum(["string", "number", "boolean", "object"]),
+            description: z.string(),
+            required: z.boolean(),
+          }),
+        ),
+      }),
+    },
+    async (input) => {
+      const ok = await confirm(input.summary);
+      if (!ok) {
+        return { content: [{ type: "text" as const, text: "User declined; no workflow added." }] };
+      }
+
+      await registry.writeWorkflow(input.workflow);
+      await registry.commit({
+        trigger: "additive-learning",
+        actor: "agent",
+        message: `meta: add workflow — ${input.summary}`,
+      });
+
+      return {
+        content: [
+          { type: "text" as const, text: `Workflow ${input.workflow.name} added and committed.` },
+        ],
+      };
+    },
+  );
+
+  return createSdkMcpServer({
+    name: "specialist-meta",
+    version: "0.1.0",
+    tools: [reactiveFix, updateWrapper, addWorkflow],
+  });
+}

--- a/src/skills/proving.ts
+++ b/src/skills/proving.ts
@@ -1,0 +1,136 @@
+import { promises as fs } from "node:fs";
+import type { TenantWorkspace } from "../tenant/workspace.js";
+import type { SkillRegistry } from "./registry.js";
+
+/**
+ * "Unproven" tracker for the auto-rollback guardrail.
+ *
+ * Spec: "If a freshly-merged skill version fails on its first production
+ * invocation, the agent reverts the commit and falls back to the prior
+ * version."
+ *
+ * Scope: only meta-tool merges (reactive_fix, update_wrapper) flag the
+ * wrapper as unproven. Synthesis goes through replay validation and is
+ * left out of this loop.
+ *
+ * State lives at tenants/<id>/.specialist-state.json. Writes go through
+ * SafeFs so they can never escape the workspace.
+ */
+
+interface UnprovenEntry {
+  commit: string;
+  mergedAt: string;
+}
+
+interface State {
+  unproven: Record<string, UnprovenEntry>;
+}
+
+async function readState(workspace: TenantWorkspace): Promise<State> {
+  try {
+    const raw = await fs.readFile(workspace.stateFile, "utf8");
+    const parsed = JSON.parse(raw) as Partial<State>;
+    return { unproven: parsed.unproven ?? {} };
+  } catch {
+    return { unproven: {} };
+  }
+}
+
+async function writeState(workspace: TenantWorkspace, state: State): Promise<void> {
+  await workspace.safeFs.writeFile(workspace.stateFile, JSON.stringify(state, null, 2) + "\n");
+}
+
+export async function markUnproven(
+  workspace: TenantWorkspace,
+  wrapperName: string,
+  commit: string,
+): Promise<void> {
+  const state = await readState(workspace);
+  state.unproven[wrapperName] = { commit, mergedAt: new Date().toISOString() };
+  await writeState(workspace, state);
+}
+
+export async function isUnproven(
+  workspace: TenantWorkspace,
+  wrapperName: string,
+): Promise<UnprovenEntry | null> {
+  const state = await readState(workspace);
+  return state.unproven[wrapperName] ?? null;
+}
+
+export async function clearUnproven(
+  workspace: TenantWorkspace,
+  wrapperName: string,
+): Promise<void> {
+  const state = await readState(workspace);
+  if (!(wrapperName in state.unproven)) return;
+  delete state.unproven[wrapperName];
+  await writeState(workspace, state);
+}
+
+/**
+ * The wrapper failed on its first post-merge invocation. Revert the
+ * commit, clear the mark, and append a line to rollback.log so the
+ * host can review.
+ */
+export async function failUnproven(
+  workspace: TenantWorkspace,
+  wrapperName: string,
+  registry: SkillRegistry,
+  reason: string,
+): Promise<void> {
+  const entry = await isUnproven(workspace, wrapperName);
+  if (!entry) return;
+
+  // Revert before clearing the mark so a crash mid-flight doesn't
+  // leave a permanent mark behind. The revert itself is idempotent —
+  // git revert <hash> against an already-reverted hash is a no-op.
+  await registry.revertLastCommit();
+  await clearUnproven(workspace, wrapperName);
+
+  const line = JSON.stringify({
+    at: new Date().toISOString(),
+    wrapper: wrapperName,
+    revertedCommit: entry.commit,
+    reason,
+  });
+  await appendRollbackLog(workspace, line);
+}
+
+async function appendRollbackLog(workspace: TenantWorkspace, line: string): Promise<void> {
+  let existing = "";
+  try {
+    existing = await fs.readFile(workspace.rollbackLog, "utf8");
+  } catch {
+    // File doesn't exist yet — fine.
+  }
+  await workspace.safeFs.writeFile(workspace.rollbackLog, existing + line + "\n");
+}
+
+/**
+ * Parse a wrapper-CLI bash command back into <vendor>.<function>.
+ * Returns null if the command isn't a wrapper invocation.
+ */
+export function parseWrapperCommand(command: string): { wrapperName: string } | null {
+  // The agent invokes via:
+  //   npx tsx <abs-path>/wrapper.ts <vendor> <function> --... --tenant=...
+  //   specialist-wrapper <vendor> <function> ...
+  const tokens = command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g);
+  if (!tokens) return null;
+
+  // Find the index of either wrapper.ts or specialist-wrapper.
+  let cliIdx = -1;
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i] ?? "";
+    if (t.endsWith("/wrapper.ts") || t === "wrapper.ts" || t === "specialist-wrapper") {
+      cliIdx = i;
+      break;
+    }
+  }
+  if (cliIdx === -1) return null;
+
+  const vendor = tokens[cliIdx + 1];
+  const fn = tokens[cliIdx + 2];
+  if (!vendor || !fn || vendor.startsWith("--") || fn.startsWith("--")) return null;
+  return { wrapperName: `${vendor}.${fn}` };
+}

--- a/src/skills/registry.ts
+++ b/src/skills/registry.ts
@@ -3,6 +3,9 @@ import path from "node:path";
 import type { TenantWorkspace } from "../tenant/workspace.js";
 import type { CommitContext, SkillMetadata, SynthesisResult, WrapperSpec } from "../types.js";
 
+// All filesystem writes here go through workspace.safeFs — see safe-fs.ts.
+// `fs` is only retained for reads, which are unrestricted.
+
 /**
  * Git-backed skill registry. Every mutation is a commit. Branches are
  * used for in-flight changes that haven't passed validation; merge to
@@ -29,19 +32,19 @@ export class SkillRegistry {
 
   async writeWrapper(spec: WrapperSpec, implementation: string): Promise<void> {
     const dir = this.workspace.skillDir(spec.name);
-    await fs.mkdir(dir, { recursive: true });
+    await this.workspace.safeFs.mkdir(dir, { recursive: true });
 
     const skillMd = renderWrapperSkillMd(spec);
-    await fs.writeFile(path.join(dir, "SKILL.md"), skillMd, "utf8");
+    await this.workspace.safeFs.writeFile(path.join(dir, "SKILL.md"), skillMd);
 
     await this.upsertServiceFunction(spec, implementation);
   }
 
   async writeWorkflow(workflow: SynthesisResult["workflow"]): Promise<void> {
     const dir = this.workspace.skillDir(workflow.name);
-    await fs.mkdir(dir, { recursive: true });
+    await this.workspace.safeFs.mkdir(dir, { recursive: true });
     const md = renderWorkflowSkillMd(workflow);
-    await fs.writeFile(path.join(dir, "SKILL.md"), md, "utf8");
+    await this.workspace.safeFs.writeFile(path.join(dir, "SKILL.md"), md);
   }
 
   /**
@@ -77,7 +80,7 @@ export class SkillRegistry {
       }
     }
 
-    await fs.writeFile(file, next, "utf8");
+    await this.workspace.safeFs.writeFile(file, next);
   }
 
   async commit(ctx: CommitContext): Promise<string> {

--- a/src/skills/registry.ts
+++ b/src/skills/registry.ts
@@ -1,0 +1,269 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { TenantWorkspace } from "../tenant/workspace.js";
+import type { CommitContext, SkillMetadata, SynthesisResult, WrapperSpec } from "../types.js";
+
+/**
+ * Git-backed skill registry. Every mutation is a commit. Branches are
+ * used for in-flight changes that haven't passed validation; merge to
+ * main only after replay succeeds.
+ */
+export class SkillRegistry {
+  constructor(private workspace: TenantWorkspace) {}
+
+  async writeSynthesisResult(result: SynthesisResult): Promise<{ workflow: string; wrappers: string[] }> {
+    await this.workspace.ensure();
+
+    // Layer 1: wrapper skills + service code
+    const wrapperNames: string[] = [];
+    for (const w of result.wrappers) {
+      await this.writeWrapper(w.spec, w.implementation);
+      wrapperNames.push(w.spec.name);
+    }
+
+    // Layer 2: workflow skill (pure markdown)
+    await this.writeWorkflow(result.workflow);
+
+    return { workflow: result.workflow.name, wrappers: wrapperNames };
+  }
+
+  async writeWrapper(spec: WrapperSpec, implementation: string): Promise<void> {
+    const dir = this.workspace.skillDir(spec.name);
+    await fs.mkdir(dir, { recursive: true });
+
+    const skillMd = renderWrapperSkillMd(spec);
+    await fs.writeFile(path.join(dir, "SKILL.md"), skillMd, "utf8");
+
+    await this.upsertServiceFunction(spec, implementation);
+  }
+
+  async writeWorkflow(workflow: SynthesisResult["workflow"]): Promise<void> {
+    const dir = this.workspace.skillDir(workflow.name);
+    await fs.mkdir(dir, { recursive: true });
+    const md = renderWorkflowSkillMd(workflow);
+    await fs.writeFile(path.join(dir, "SKILL.md"), md, "utf8");
+  }
+
+  /**
+   * Append (or replace) a function in the per-vendor service file.
+   * The file is regenerated from a marker-delimited block per function
+   * so synthesis can call this idempotently.
+   */
+  async upsertServiceFunction(spec: WrapperSpec, implementation: string): Promise<void> {
+    const file = this.workspace.serviceFile(spec.vendor);
+    let existing = "";
+    try {
+      existing = await fs.readFile(file, "utf8");
+    } catch {
+      existing = renderServiceFileHeader(spec.vendor);
+    }
+
+    const block = renderFunctionBlock(spec, implementation);
+    const startMarker = `// >>> ${spec.name}`;
+    const endMarker = `// <<< ${spec.name}`;
+
+    let next: string;
+    const startIdx = existing.indexOf(startMarker);
+    if (startIdx === -1) {
+      next = existing.trimEnd() + "\n\n" + block + "\n";
+    } else {
+      const endIdx = existing.indexOf(endMarker, startIdx);
+      if (endIdx === -1) {
+        next = existing.trimEnd() + "\n\n" + block + "\n";
+      } else {
+        const before = existing.slice(0, startIdx);
+        const after = existing.slice(endIdx + endMarker.length);
+        next = before + block + after;
+      }
+    }
+
+    await fs.writeFile(file, next, "utf8");
+  }
+
+  async commit(ctx: CommitContext): Promise<string> {
+    await this.workspace.git("add", "-A");
+    // Skip if nothing staged — git commit -q would otherwise fail.
+    const { stdout } = await this.workspace.git("status", "--porcelain");
+    if (!stdout.trim()) return "";
+    const meta = JSON.stringify({
+      trigger: ctx.trigger,
+      actor: ctx.actor,
+      validation: ctx.validation,
+    });
+    const message = `${ctx.message}\n\n${meta}`;
+    await this.workspace.git("commit", "-q", "-m", message);
+    const { stdout: hash } = await this.workspace.git("rev-parse", "HEAD");
+    return hash.trim();
+  }
+
+  async revertLastCommit(): Promise<void> {
+    await this.workspace.git("revert", "--no-edit", "HEAD");
+  }
+
+  async checkoutBranch(name: string): Promise<void> {
+    await this.workspace.git("checkout", "-B", name);
+  }
+
+  async mergeToMain(branch: string): Promise<void> {
+    await this.workspace.git("checkout", "main");
+    await this.workspace.git("merge", "--ff-only", branch);
+  }
+
+  async readSkill(name: string): Promise<{ metadata: Partial<SkillMetadata>; body: string } | null> {
+    try {
+      const md = await fs.readFile(path.join(this.workspace.skillDir(name), "SKILL.md"), "utf8");
+      return parseSkillMd(md);
+    } catch {
+      return null;
+    }
+  }
+}
+
+function renderWrapperSkillMd(spec: WrapperSpec): string {
+  const params = spec.parameters
+    .map((p) => `- \`${p.name}\` (${p.type}${p.required ? ", required" : ", optional"}): ${p.description}`)
+    .join("\n");
+
+  const usageArgs = spec.parameters
+    .filter((p) => p.required)
+    .map((p) => `--${p.name}=<${p.name}>`)
+    .join(" ");
+
+  return `---
+name: ${spec.name}
+description: ${spec.description} Use when: ${spec.whenToUse}
+kind: wrapper
+vendor: ${spec.vendor}
+---
+
+# ${spec.name}
+
+${spec.description}
+
+## When to use
+
+${spec.whenToUse}
+
+## HTTP call
+
+\`${spec.http.method} ${spec.http.urlTemplate}\` — ${spec.http.contentType}
+
+## Inputs
+
+${params || "_(none)_"}
+
+## Returns
+
+${spec.returns}
+
+## Invocation
+
+Run from a shell:
+
+\`\`\`bash
+specialist-wrapper ${spec.vendor} ${spec.name.split(".").pop() ?? spec.name} ${usageArgs}
+\`\`\`
+
+The wrapper returns parsed JSON on stdout. On error it exits non-zero with diagnostics on stderr.
+`;
+}
+
+function renderWorkflowSkillMd(workflow: SynthesisResult["workflow"]): string {
+  const inputs = workflow.inputs
+    .map((p) => `- \`${p.name}\` (${p.type}${p.required ? ", required" : ", optional"}): ${p.description}`)
+    .join("\n");
+
+  const steps = workflow.steps.map((s, i) => `${i + 1}. ${s}`).join("\n");
+
+  return `---
+name: ${workflow.name}
+description: ${workflow.description} Use when: ${workflow.whenToUse}
+kind: workflow
+---
+
+# ${workflow.name}
+
+${workflow.description}
+
+## When to use
+
+${workflow.whenToUse}
+
+## Inputs
+
+${inputs || "_(none)_"}
+
+## Steps
+
+${steps}
+
+## Notes
+
+- Wrappers referenced by name resolve to skills under \`.claude/skills/\`.
+- For each step, identify the right wrapper from the prompt + prior step responses, extract arguments, and invoke via shell.
+- If a wrapper call fails, load the wrapper's SKILL.md, the failed request/response, and prior successful steps, then re-reason the next move. If the failure looks like persistent drift, invoke \`meta.update_skill\` to fix the wrapper.
+`;
+}
+
+function renderServiceFileHeader(vendor: string): string {
+  return `// ${vendor} service lib — generated by specialist-agent.
+//
+// Each exported function is a thin HTTP wrapper. No retry logic, no response
+// shaping, no convenience parameters. Smarter behavior belongs in a workflow
+// skill or in the agent's reasoning layer.
+//
+// Auth is supplied by the AuthBroker at call time.
+
+import { runWrapper } from "../../../src/execution/runner.js";
+
+`;
+}
+
+function renderFunctionBlock(spec: WrapperSpec, implementation: string): string {
+  const params = spec.parameters
+    .map((p) => `${p.name}${p.required ? "" : "?"}: ${tsType(p.type)}`)
+    .join("; ");
+  const fnName = spec.name.split(".").pop() ?? spec.name;
+  return `// >>> ${spec.name}
+export async function ${fnName}(args: { ${params} }): Promise<unknown> {
+${indent(implementation.trim(), 2)}
+}
+// <<< ${spec.name}`;
+}
+
+function tsType(t: string): string {
+  switch (t) {
+    case "string":
+      return "string";
+    case "number":
+      return "number";
+    case "boolean":
+      return "boolean";
+    default:
+      return "Record<string, unknown>";
+  }
+}
+
+function indent(s: string, n: number): string {
+  const pad = " ".repeat(n);
+  return s
+    .split("\n")
+    .map((line) => (line ? pad + line : line))
+    .join("\n");
+}
+
+function parseSkillMd(md: string): { metadata: Partial<SkillMetadata>; body: string } {
+  const m = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/.exec(md);
+  if (!m) return { metadata: {}, body: md };
+  const front = m[1] ?? "";
+  const body = m[2] ?? "";
+  const metadata: Record<string, string> = {};
+  for (const line of front.split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    const k = line.slice(0, idx).trim();
+    const v = line.slice(idx + 1).trim();
+    metadata[k] = v;
+  }
+  return { metadata: metadata as Partial<SkillMetadata>, body };
+}

--- a/src/skills/safe-fs.ts
+++ b/src/skills/safe-fs.ts
@@ -1,0 +1,93 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { TenantWorkspace } from "../tenant/workspace.js";
+
+/**
+ * Filesystem gate for everything the meta tools and registry write.
+ *
+ * The architecture doc says scope limits should be "enforced via filesystem
+ * permissions, not just convention." A real OS-permission sandbox needs a
+ * subprocess with bind mounts; that's out of scope for v1. SafeFs instead
+ * funnels every write through one validator that resolves the target path
+ * and asserts it lives inside one of these allowlisted prefixes:
+ *
+ *   .claude/skills/         — wrapper + workflow skill files
+ *   services/               — generated wrapper functions
+ *   .specialist-state.json  — proving tracker
+ *   rollback.log            — rollback audit trail
+ *
+ * Anything else throws ScopeViolationError. As long as the meta tools and
+ * registry never bypass SafeFs, the agent cannot edit the auth broker, the
+ * runtime, or itself — even under prompt injection.
+ */
+export class SafeFs {
+  constructor(private workspace: TenantWorkspace) {}
+
+  async writeFile(absPath: string, content: string): Promise<void> {
+    this.assertWithin(absPath);
+    await fs.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.writeFile(absPath, content, "utf8");
+  }
+
+  async mkdir(absPath: string, opts: { recursive?: boolean } = {}): Promise<void> {
+    this.assertWithin(absPath);
+    await fs.mkdir(absPath, { recursive: opts.recursive ?? false });
+  }
+
+  async unlink(absPath: string): Promise<void> {
+    this.assertWithin(absPath);
+    await fs.unlink(absPath);
+  }
+
+  async readFile(absPath: string): Promise<string> {
+    // Reads don't need the same gate (the agent could read anything via
+    // the SDK's Read tool anyway), but routing them through SafeFs keeps
+    // call sites uniform.
+    return fs.readFile(absPath, "utf8");
+  }
+
+  /**
+   * Resolve absPath, normalize traversal, and reject anything outside the
+   * allowlist. Symlink escape is mitigated by `path.resolve` collapsing
+   * `..` segments before the prefix check; symlinks pointing outside
+   * still pass the string check (a real attacker would need write access
+   * to plant the symlink, which they wouldn't have without already being
+   * past SafeFs). For v1 this is the right tradeoff.
+   */
+  private assertWithin(absPath: string): void {
+    const resolved = path.resolve(absPath);
+    const root = path.resolve(this.workspace.root);
+    const rel = path.relative(root, resolved);
+
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
+      throw new ScopeViolationError(
+        `path "${absPath}" is outside tenant workspace ${root}`,
+      );
+    }
+
+    const allowlist = [
+      ".claude/skills",
+      "services",
+      ".specialist-state.json",
+      "rollback.log",
+    ];
+
+    const ok = allowlist.some((prefix) => {
+      if (rel === prefix) return true;
+      return rel.startsWith(prefix + path.sep);
+    });
+
+    if (!ok) {
+      throw new ScopeViolationError(
+        `path "${rel}" is not in the SafeFs allowlist (allowed: ${allowlist.join(", ")})`,
+      );
+    }
+  }
+}
+
+export class ScopeViolationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ScopeViolationError";
+  }
+}

--- a/src/synthesis/prompt.ts
+++ b/src/synthesis/prompt.ts
@@ -27,6 +27,7 @@ Discipline for wrappers:
         });
 - Wrapper names use dotted form: "<vendor>.<verb_object>", e.g. "stripe.create_invoice".
 - Vendor is the apex domain's brand (stripe, github, slack, linear, asana, notion, etc.).
+- For every parameter you define, emit the literal value you observed for it in the trace under \`observedValues\`. The user will be shown each (parameter, observed-value) pair and asked whether it should stay a parameter or be frozen as a constant. If you didn't see an observed value (the parameter is genuinely optional), emit \`null\`.
 
 Discipline for the workflow:
 - Pure markdown body. Reference wrappers by name, describe parameter plumbing in plain English, do NOT reproduce request/response shapes.

--- a/src/synthesis/prompt.ts
+++ b/src/synthesis/prompt.ts
@@ -1,0 +1,76 @@
+import type { HttpTrace } from "../types.js";
+
+export const SYNTHESIS_SYSTEM_PROMPT = `You synthesize learned skills from a customer's HTTP trace.
+
+You will be given:
+1. The user's stated intent (one sentence describing what they did).
+2. A scrubbed HTTP trace — request/response pairs in order, with auth values replaced by {{auth}}.
+3. The set of wrapper skills the agent already has (so you can reuse them).
+
+Your job:
+- Identify which HTTP endpoints in the trace are NEW (no existing wrapper covers them) versus reused.
+- For each NEW endpoint, design a thin Layer-1 wrapper skill: SKILL.md + a tiny TypeScript function body.
+- Design ONE Layer-2 workflow skill (pure prose) that describes the user's task as an ordered sequence of wrapper calls.
+
+Discipline for wrappers:
+- One wrapper per endpoint. No retry logic, no response shaping, no convenience parameters. Just: build URL, inject auth, send request, return parsed response.
+- Identify which values in the request are likely INPUTS (parameterize them) versus CONSTANTS (hardcode them).
+- When uncertain, prefer parameterizing — humans can always confirm and freeze parameters later.
+- The implementation body has access to:
+    - args: the typed parameter object (already validated for required fields)
+    - runWrapper(opts): a helper that wraps fetch with auth injection. Use it like:
+        return runWrapper({
+          vendor: "<vendor>",
+          method: "POST",
+          url: \`https://api.example.com/v1/things/\${args.id}\`,
+          body: { name: args.name },
+        });
+- Wrapper names use dotted form: "<vendor>.<verb_object>", e.g. "stripe.create_invoice".
+- Vendor is the apex domain's brand (stripe, github, slack, linear, asana, notion, etc.).
+
+Discipline for the workflow:
+- Pure markdown body. Reference wrappers by name, describe parameter plumbing in plain English, do NOT reproduce request/response shapes.
+- The workflow name should be snake_case and reflect the user's intent (e.g. "create_paid_invoice_for_new_customer").
+
+Return STRICT JSON matching the provided schema. No additional fields.`;
+
+export function renderUserPrompt(args: {
+  trace: HttpTrace;
+  existingWrappers: Array<{ name: string; description: string }>;
+}): string {
+  const summary = args.trace.requests.map((ex) => {
+    const url = ex.request.url;
+    const method = ex.request.method;
+    return {
+      i: ex.index,
+      method,
+      url,
+      status: ex.response.status,
+      requestBody: ex.request.body,
+      responseBody: truncateForPrompt(ex.response.body),
+    };
+  });
+
+  return [
+    `# Intent`,
+    args.trace.intent,
+    "",
+    `# Existing wrapper skills (reuse if they fit)`,
+    args.existingWrappers.length === 0
+      ? "_(none yet)_"
+      : args.existingWrappers.map((w) => `- ${w.name}: ${w.description}`).join("\n"),
+    "",
+    `# HTTP trace (${summary.length} exchanges)`,
+    "```json",
+    JSON.stringify(summary, null, 2),
+    "```",
+  ].join("\n");
+}
+
+function truncateForPrompt(body: unknown): unknown {
+  const s = JSON.stringify(body);
+  if (s == null) return body;
+  if (s.length <= 4000) return body;
+  // Keep enough shape to infer the schema, drop the bulk.
+  return { _truncated: true, preview: s.slice(0, 4000) };
+}

--- a/src/synthesis/synthesize.ts
+++ b/src/synthesis/synthesize.ts
@@ -1,0 +1,121 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { HttpTrace, SynthesisResult } from "../types.js";
+import { SYNTHESIS_SYSTEM_PROMPT, renderUserPrompt } from "./prompt.js";
+
+const SYNTHESIS_MODEL = "claude-opus-4-7";
+
+const SYNTHESIS_TOOL = {
+  name: "emit_skills",
+  description: "Emit the synthesized wrapper skills and workflow skill.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      workflow: {
+        type: "object",
+        properties: {
+          name: { type: "string", description: "snake_case identifier" },
+          description: { type: "string" },
+          whenToUse: { type: "string" },
+          steps: {
+            type: "array",
+            items: { type: "string" },
+            description: "Ordered prose steps referencing wrapper names.",
+          },
+          inputs: { type: "array", items: parameterSchema() },
+        },
+        required: ["name", "description", "whenToUse", "steps", "inputs"],
+      },
+      wrappers: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            spec: {
+              type: "object",
+              properties: {
+                name: { type: "string", description: "dotted form: <vendor>.<verb_object>" },
+                vendor: { type: "string" },
+                description: { type: "string" },
+                whenToUse: { type: "string" },
+                http: {
+                  type: "object",
+                  properties: {
+                    method: { type: "string" },
+                    urlTemplate: { type: "string", description: "URL with {arg} placeholders" },
+                    contentType: { type: "string" },
+                  },
+                  required: ["method", "urlTemplate", "contentType"],
+                },
+                parameters: { type: "array", items: parameterSchema() },
+                returns: { type: "string", description: "Plain-English description of the response shape." },
+              },
+              required: ["name", "vendor", "description", "whenToUse", "http", "parameters", "returns"],
+            },
+            implementation: {
+              type: "string",
+              description:
+                "TypeScript function body (without signature) that returns runWrapper({...}). Has access to `args` and `runWrapper`.",
+            },
+          },
+          required: ["spec", "implementation"],
+        },
+      },
+    },
+    required: ["workflow", "wrappers"],
+  },
+};
+
+function parameterSchema() {
+  return {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+      type: { type: "string", enum: ["string", "number", "boolean", "object"] },
+      description: { type: "string" },
+      required: { type: "boolean" },
+    },
+    required: ["name", "type", "description", "required"],
+  };
+}
+
+/**
+ * Single Claude call: trimmed HTTP trace + user intent → wrapper + workflow skills.
+ *
+ * Uses prompt caching on the system prompt because in production this synth
+ * call gets made many times per day per tenant.
+ */
+export async function synthesizeFromTrace(args: {
+  trace: HttpTrace;
+  existingWrappers: Array<{ name: string; description: string }>;
+  client?: Anthropic;
+}): Promise<SynthesisResult> {
+  const client = args.client ?? new Anthropic();
+  const userPrompt = renderUserPrompt({
+    trace: args.trace,
+    existingWrappers: args.existingWrappers,
+  });
+
+  const response = await client.messages.create({
+    model: SYNTHESIS_MODEL,
+    max_tokens: 16000,
+    system: [
+      {
+        type: "text",
+        text: SYNTHESIS_SYSTEM_PROMPT,
+        cache_control: { type: "ephemeral" },
+      },
+    ],
+    tools: [SYNTHESIS_TOOL],
+    tool_choice: { type: "tool", name: SYNTHESIS_TOOL.name },
+    messages: [{ role: "user", content: userPrompt }],
+  });
+
+  const toolUse = response.content.find(
+    (b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
+  );
+  if (!toolUse) {
+    throw new Error("Synthesis call returned no tool_use block.");
+  }
+
+  return toolUse.input as SynthesisResult;
+}

--- a/src/synthesis/synthesize.ts
+++ b/src/synthesis/synthesize.ts
@@ -1,5 +1,10 @@
 import Anthropic from "@anthropic-ai/sdk";
-import type { HttpTrace, SynthesisResult } from "../types.js";
+import type {
+  HttpTrace,
+  ParameterDecision,
+  SynthesisResult,
+  WrapperSpec,
+} from "../types.js";
 import { SYNTHESIS_SYSTEM_PROMPT, renderUserPrompt } from "./prompt.js";
 
 const SYNTHESIS_MODEL = "claude-opus-4-7";
@@ -56,8 +61,14 @@ const SYNTHESIS_TOOL = {
               description:
                 "TypeScript function body (without signature) that returns runWrapper({...}). Has access to `args` and `runWrapper`.",
             },
+            observedValues: {
+              type: "object",
+              description:
+                "Per-parameter sample values pulled from the trace. Keys are parameter names; values are the literal observed in the request. Used to drive a 'is this a constant?' confirmation pass with the user.",
+              additionalProperties: true,
+            },
           },
-          required: ["spec", "implementation"],
+          required: ["spec", "implementation", "observedValues"],
         },
       },
     },
@@ -118,4 +129,78 @@ export async function synthesizeFromTrace(args: {
   }
 
   return toolUse.input as SynthesisResult;
+}
+
+/**
+ * Apply the host's parameter decisions to one wrapper. Each `freeze`
+ * decision drops the parameter from `spec.parameters`, inlines its constant
+ * into both the `urlTemplate` and the implementation source, and updates
+ * the description string in the SKILL.md so the wrapper accurately reflects
+ * what the agent will see at invocation time.
+ *
+ * Returns a new spec + implementation. Inputs are not mutated.
+ */
+export function applyParameterDecisions(args: {
+  spec: WrapperSpec;
+  implementation: string;
+  decisions: Record<string, ParameterDecision>;
+}): { spec: WrapperSpec; implementation: string } {
+  let urlTemplate = args.spec.http.urlTemplate;
+  let implementation = args.implementation;
+  const remaining: typeof args.spec.parameters = [];
+
+  for (const param of args.spec.parameters) {
+    const decision = args.decisions[param.name] ?? { action: "keep" };
+    if (decision.action === "keep") {
+      remaining.push(param);
+      continue;
+    }
+    const literal = formatLiteral(decision.constantValue, param.type);
+    const stringLiteral = stringFormOf(decision.constantValue);
+
+    // {arg} placeholders in the URL template are inlined as plain strings.
+    urlTemplate = urlTemplate.split(`{${param.name}}`).join(stringLiteral);
+    urlTemplate = urlTemplate.split(`\${args.${param.name}}`).join(stringLiteral);
+
+    // args.foo references in the function body become literal expressions.
+    // Order matters: the longer template-literal form first.
+    implementation = implementation.split(`\${args.${param.name}}`).join(stringLiteral);
+    implementation = implementation
+      .split(new RegExp(`\\bargs\\.${escapeRegex(param.name)}\\b`))
+      .join(literal);
+  }
+
+  return {
+    spec: {
+      ...args.spec,
+      parameters: remaining,
+      http: { ...args.spec.http, urlTemplate },
+    },
+    implementation,
+  };
+}
+
+function formatLiteral(value: unknown, type: WrapperSpec["parameters"][number]["type"]): string {
+  switch (type) {
+    case "string":
+      return JSON.stringify(typeof value === "string" ? value : String(value));
+    case "number":
+      return String(typeof value === "number" ? value : Number(value));
+    case "boolean":
+      return String(Boolean(value));
+    default:
+      // Object/structured: serialize and trust the implementation context.
+      return JSON.stringify(value);
+  }
+}
+
+function stringFormOf(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return JSON.stringify(value);
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/tenant/workspace.ts
+++ b/src/tenant/workspace.ts
@@ -3,6 +3,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import path from "node:path";
 import type { TenantConfig } from "../types.js";
+import { SafeFs } from "../skills/safe-fs.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -11,9 +12,16 @@ const execFileAsync = promisify(execFile);
  *   .claude/skills/        — per-skill folders (SKILL.md + supporting files)
  *   services/              — generated TypeScript wrapper libs, one file per vendor
  *   .git/                  — every skill change is a commit
+ *
+ * Writes by the registry and meta tools go through `safeFs`, which enforces
+ * the scope limit from the architecture doc.
  */
 export class TenantWorkspace {
-  constructor(public readonly config: TenantConfig) {}
+  readonly safeFs: SafeFs;
+
+  constructor(public readonly config: TenantConfig) {
+    this.safeFs = new SafeFs(this);
+  }
 
   get root(): string {
     return this.config.workspacePath;
@@ -33,6 +41,14 @@ export class TenantWorkspace {
 
   serviceFile(vendor: string): string {
     return path.join(this.servicesDir, `${vendor}.ts`);
+  }
+
+  get stateFile(): string {
+    return path.join(this.root, ".specialist-state.json");
+  }
+
+  get rollbackLog(): string {
+    return path.join(this.root, "rollback.log");
   }
 
   async ensure(): Promise<void> {

--- a/src/tenant/workspace.ts
+++ b/src/tenant/workspace.ts
@@ -1,0 +1,73 @@
+import { promises as fs } from "node:fs";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import path from "node:path";
+import type { TenantConfig } from "../types.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * A tenant workspace is a self-contained directory containing:
+ *   .claude/skills/        — per-skill folders (SKILL.md + supporting files)
+ *   services/              — generated TypeScript wrapper libs, one file per vendor
+ *   .git/                  — every skill change is a commit
+ */
+export class TenantWorkspace {
+  constructor(public readonly config: TenantConfig) {}
+
+  get root(): string {
+    return this.config.workspacePath;
+  }
+
+  get skillsDir(): string {
+    return path.join(this.root, ".claude", "skills");
+  }
+
+  get servicesDir(): string {
+    return path.join(this.root, "services");
+  }
+
+  skillDir(name: string): string {
+    return path.join(this.skillsDir, name);
+  }
+
+  serviceFile(vendor: string): string {
+    return path.join(this.servicesDir, `${vendor}.ts`);
+  }
+
+  async ensure(): Promise<void> {
+    await fs.mkdir(this.skillsDir, { recursive: true });
+    await fs.mkdir(this.servicesDir, { recursive: true });
+
+    const gitDir = path.join(this.root, ".git");
+    try {
+      await fs.access(gitDir);
+    } catch {
+      await this.git("init", "-q", "-b", "main");
+      await this.git("config", "user.email", "agent@specialist.local");
+      await this.git("config", "user.name", "Specialist Agent");
+      // Seed an initial commit so branches can be created cleanly.
+      const readme = path.join(this.root, "README.md");
+      await fs.writeFile(
+        readme,
+        `# Tenant: ${this.config.id}\n\nPer-tenant skill registry. Managed by the specialist agent.\n`,
+      );
+      await this.git("add", "README.md");
+      await this.git("commit", "-q", "-m", "init tenant workspace");
+    }
+  }
+
+  async git(...args: string[]): Promise<{ stdout: string; stderr: string }> {
+    const { stdout, stderr } = await execFileAsync("git", args, { cwd: this.root });
+    return { stdout, stderr };
+  }
+
+  async listSkillNames(): Promise<string[]> {
+    try {
+      const entries = await fs.readdir(this.skillsDir, { withFileTypes: true });
+      return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+    } catch {
+      return [];
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,99 @@
+// Shared types for the specialist agent.
+//
+// HTTP traces are the source of truth for everything the agent learns.
+// Skills are derived from traces, stored on disk, and version-controlled in git.
+
+export interface HttpTrace {
+  id: string;
+  startedAt: string;
+  endedAt: string;
+  intent: string;
+  requests: HttpExchange[];
+}
+
+export interface HttpExchange {
+  index: number;
+  request: {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    body: unknown;
+    timestamp: string;
+  };
+  response: {
+    status: number;
+    headers: Record<string, string>;
+    body: unknown;
+    durationMs: number;
+  };
+}
+
+export type SkillKind = "wrapper" | "workflow";
+
+export interface SkillMetadata {
+  name: string;
+  description: string;
+  kind: SkillKind;
+  vendor?: string;
+  createdAt: string;
+  updatedAt: string;
+  validatedAt?: string;
+  source: "synthesis" | "user-instruction" | "reactive-fix" | "additive-learning";
+}
+
+export interface WrapperParameter {
+  name: string;
+  type: "string" | "number" | "boolean" | "object";
+  description: string;
+  required: boolean;
+}
+
+export interface WrapperSpec {
+  name: string;
+  vendor: string;
+  description: string;
+  whenToUse: string;
+  http: {
+    method: string;
+    urlTemplate: string;
+    contentType: string;
+  };
+  parameters: WrapperParameter[];
+  returns: string;
+}
+
+export interface WorkflowSpec {
+  name: string;
+  description: string;
+  whenToUse: string;
+  steps: string[];
+  inputs: WrapperParameter[];
+}
+
+export interface SynthesisResult {
+  workflow: WorkflowSpec;
+  wrappers: Array<{
+    spec: WrapperSpec;
+    /** TypeScript function source body (the part inside the function — no signature). */
+    implementation: string;
+  }>;
+}
+
+export interface TenantConfig {
+  id: string;
+  /** Per-tenant filesystem root: contains the .claude/skills/ tree and services/ libs. */
+  workspacePath: string;
+  /** API key environment variable name to read from per-call. */
+  authEnvVar?: string;
+}
+
+export interface CommitContext {
+  trigger: SkillMetadata["source"];
+  actor: "agent" | "human";
+  message: string;
+  validation?: {
+    replayed: boolean;
+    success: boolean;
+    notes?: string;
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,8 +76,23 @@ export interface SynthesisResult {
     spec: WrapperSpec;
     /** TypeScript function source body (the part inside the function — no signature). */
     implementation: string;
+    /**
+     * Per-parameter sample values pulled from the trace. Drives the
+     * "Is `"USD"` a wrapper input or a constant?" confirmation pass.
+     * Keyed by parameter name; values are the literal observed in the trace.
+     */
+    observedValues: Record<string, unknown>;
   }>;
 }
+
+/**
+ * Decision returned by the host for one parameter during the confirmation
+ * pass. `keep` leaves the parameter as-is. `freeze` removes it from the
+ * spec and inlines `constantValue` into the wrapper body.
+ */
+export type ParameterDecision =
+  | { action: "keep" }
+  | { action: "freeze"; constantValue: unknown };
 
 export interface TenantConfig {
   id: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2023", "DOM"],
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": false,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src/**/*", "examples/**/*"],
+  "exclude": ["node_modules", "dist", "tenants"]
+}


### PR DESCRIPTION
## Summary

Implements the specialist agent architecture from the task description, end-to-end on the latest TypeScript Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`).

- **Two-layer skills.** Atomic wrappers (one per HTTP endpoint, thin TS function + `SKILL.md`) and compositional workflows (pure markdown). Loaded by the SDK via `settingSources: ["project"]` against a per-tenant `cwd`.
- **Synthesis.** One Claude `messages.create` call with a forced tool_use schema turns a scrubbed HTTP trace + intent into wrapper specs + a workflow. Auth headers are stripped at capture time.
- **Git-backed registry.** Every skill change is a commit on a per-tenant repo. Branches for in-flight changes; merge to `main` only after replay succeeds.
- **`meta.update_skill` MCP server.** Three tools (`reactive_fix`, `update_wrapper`, `add_workflow`) with the guardrails from the doc — auto for clear-cut drift, host-confirmed for user-instructed changes, replay-validated before merge.
- **Pluggable auth broker.** API-key / OAuth / SDK-embedded providers; the agent never sees raw secrets at rest.
- **Capture surfaces.** Fetch interceptor for the SDK-embedded path, HAR import for browser-extension / MITM exports.
- **CLIs.** `specialist-agent learn|run|log` for the host, `specialist-wrapper` for the agent's Bash invocations.

## Test plan

- [x] `npm install` clean
- [x] `npx tsc --noEmit` passes
- [x] `npm run demo` exercises HAR import → tenant init → synthesis call (verified up to the live Anthropic call; with a real `ANTHROPIC_API_KEY` it produces wrapper + workflow skills committed to `tenants/demo/`)
- [ ] End-to-end agent loop with `RUN_AGENT=1` and a real `STRIPE_API_KEY` (left to the host since it makes real Stripe calls)

## Notes

- Synthesis uses `claude-opus-4-7` with prompt caching on the system prompt.
- Auth scrubbing replaces recognized header names and obvious secret-shaped JSON keys with `{{auth}}` placeholders before anything is persisted.
- Wrappers stay deliberately thin — `runWrapper()` is the only HTTP touchpoint. Smarter behavior belongs in workflows or the agent's reasoning layer.
- Self-modification is filesystem-scoped: the meta tools only edit files under the tenant's `.claude/skills/` and `services/`.

https://claude.ai/code/session_01S3TtDAS1PULEXYnWhEAk5y

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3TtDAS1PULEXYnWhEAk5y)_