### PR TITLE
Implement browser-extension capture surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A learning agent built on the [Claude Agent SDK](https://docs.claude.com/en/agen
 | ----------------------------------------- | ----------------------------------------------------------------------- |
 | **This file**                             | Quickstart, install, project layout, scripts                            |
 | [`docs/USAGE.md`](docs/USAGE.md)          | End-to-end real-world walkthrough — capture → synthesize → run          |
-| [`docs/CAPTURE.md`](docs/CAPTURE.md)      | Three ways to capture HTTP traces: DevTools HAR, MITM proxy, SDK hook   |
+| [`docs/CAPTURE.md`](docs/CAPTURE.md)      | Four ways to capture HTTP traces: DevTools HAR, browser extension, MITM proxy, SDK hook |
+| [`browser-extension/README.md`](browser-extension/README.md) | Chrome MV3 extension that captures workflows and emits a bundle file the host CLI consumes via `--bundle=` |
 | [`docs/EMBEDDING.md`](docs/EMBEDDING.md)  | Programmatic API for embedding the agent in your own host application  |
 | [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) | Common errors and fixes                                       |
 | [`prompts/`](prompts/)                    | Briefing prompts for follow-up planning agents (next features)          |
@@ -81,11 +82,11 @@ docs/
 ## CLI reference
 
 ```bash
-# Synthesize skills from a HAR export of an observed task.
+# Synthesize skills from an observed task.
+# Either pass a HAR (with --intent) or a bundle from the browser extension.
 specialist-agent learn \
   --tenant=tenants/<id> \
-  --har=./<file>.har \
-  --intent="<one-sentence description>" \
+  (--bundle=./bundle.json | --har=./<file>.har --intent="<one-sentence description>") \
   [--auto-keep]                 # skip parameter-confirmation prompt
 
 # Run the agent against the tenant's learned skills.

--- a/browser-extension/.gitignore
+++ b/browser-extension/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.vite/
+*.log
+vendor/whisper-tiny.wasm
+vendor/whisper.js

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -29,15 +29,15 @@ npm run test       # vitest — runs scrub fixture, CDP reconstruct, HAR emit, b
 
 ## Use
 
-1. Open the SaaS app you want to teach (e.g. `dashboard.stripe.com`).
-2. Click the extension icon → **Start** (optionally tick "narrate aloud").
-3. Chrome shows a yellow CDP banner; the extension overlays a friendlier "Recording" banner with a **Stop** button.
-4. Drive the workflow. Optionally narrate aloud — the transcript fills in live (Chrome only; Web Speech sends audio to Google).
-5. Click **Stop**. The popup shows request count, total bytes, and a per-host breakdown.
-6. Edit the **intent** field and (optional) **narration** — these become the bundle's `intent` and `narrative`.
-7. Click **Download bundle** to save the `.json` to disk, or **Submit to host** to POST to your configured synthesis endpoint.
+1. **One-time setup:** open the options page and paste the synthesis backend URL + bearer token. Without an endpoint the extension still works, but bundles will save to disk instead of posting.
+2. Open the SaaS app you want to teach (e.g. `dashboard.stripe.com`).
+3. Click the extension icon → **Start** (optionally tick "narrate aloud").
+4. Chrome shows a yellow CDP banner; the extension overlays a friendlier "Recording" banner with a **Stop** button.
+5. Drive the workflow. Optionally narrate aloud — the transcript fills in live (Chrome only; Web Speech sends audio to Google).
+6. Edit the **intent** field and (optional) **narration** at any point — these become the bundle's `intent` and `narrative`.
+7. Click **Stop**. The bundle is built and **automatically POSTed to the configured backend** (`{endpoint}/v1/bundles`). The popup shows status: `Submitting…` → `Submitted to host (trace …)`. No file handling required.
 
-Then, on a machine with `specialist-agent` installed:
+If POST fails (network error, 4xx/5xx, or no endpoint configured) the extension falls back to a local download so a recording is never silently dropped. The popup surfaces the error and a **Retry submit** button. The fallback file can also be fed manually:
 
 ```bash
 specialist-agent learn \
@@ -88,7 +88,7 @@ Filename convention: `specialist-bundle-<iso8601>-<short-id>.json`.
 
 ## POST endpoint contract
 
-When the user clicks "Submit to host", the extension POSTs the bundle JSON to:
+The extension auto-submits each bundle to:
 
 ```
 POST {postEndpoint}/v1/bundles
@@ -96,7 +96,7 @@ Content-Type: application/json
 Authorization: Bearer {postBearerToken}     (omitted if blank)
 ```
 
-Server contract is documented in [`prompts/PLANS/browser-extension.md`](../prompts/PLANS/browser-extension.md) §7.2; the endpoint itself is out of scope for the extension. Errors surface as a popup error toast with a "Download instead" fallback.
+Server contract is documented in [`prompts/PLANS/browser-extension.md`](../prompts/PLANS/browser-extension.md) §7.2; the endpoint itself is out of scope for the extension. On any failure the extension writes a local download instead and exposes a Retry button — the user never has to manually export a file under the happy path.
 
 ## Layout
 

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -1,0 +1,119 @@
+# Specialist Capture (browser extension)
+
+Chrome MV3 extension that captures HTTP workflows for `specialist-agent`. Records the network conversation via the Chrome DevTools Protocol, lets the user describe the workflow (typed or voice-narrated), and emits a single bundle file that the host CLI consumes via `--bundle=...`.
+
+This is the third capture surface alongside DevTools-HAR and the in-process fetch interceptor — see [`docs/CAPTURE.md`](../docs/CAPTURE.md). The original architecture plan lives at [`prompts/PLANS/browser-extension.md`](../prompts/PLANS/browser-extension.md).
+
+## Status
+
+- **v1 (this release):** Chrome only, Web Speech transcription, download or POST submission paths, no auto-merge of multi-tab captures.
+- **v1.1 (planned):** Firefox via `webRequest.filterResponseData`, Whisper.wasm offline transcription, multi-tab merge.
+
+## Build
+
+```bash
+cd browser-extension
+npm install
+npm run build      # produces dist/
+npm run typecheck
+npm run test       # vitest — runs scrub fixture, CDP reconstruct, HAR emit, bundle build
+```
+
+## Install (Chrome, unpacked)
+
+1. `npm run build` from this directory.
+2. Open `chrome://extensions`.
+3. Enable **Developer mode** (top right).
+4. **Load unpacked** → select the `browser-extension/dist` directory.
+5. Pin the action so the popup is one click away.
+
+## Use
+
+1. Open the SaaS app you want to teach (e.g. `dashboard.stripe.com`).
+2. Click the extension icon → **Start** (optionally tick "narrate aloud").
+3. Chrome shows a yellow CDP banner; the extension overlays a friendlier "Recording" banner with a **Stop** button.
+4. Drive the workflow. Optionally narrate aloud — the transcript fills in live (Chrome only; Web Speech sends audio to Google).
+5. Click **Stop**. The popup shows request count, total bytes, and a per-host breakdown.
+6. Edit the **intent** field and (optional) **narration** — these become the bundle's `intent` and `narrative`.
+7. Click **Download bundle** to save the `.json` to disk, or **Submit to host** to POST to your configured synthesis endpoint.
+
+Then, on a machine with `specialist-agent` installed:
+
+```bash
+specialist-agent learn \
+  --tenant=tenants/acme \
+  --bundle=~/Downloads/specialist-bundle-20260502T153011Z-a3b9k2.json
+```
+
+`--bundle` and `--har` are mutually exclusive. The intent + narrative come from the bundle, so don't pass `--intent` with `--bundle`.
+
+## Permissions
+
+| Permission | Why |
+| --- | --- |
+| `debugger` | Read response bodies via the DevTools Protocol — only path on Chrome MV3 |
+| `storage` | Session captures + sync user settings (POST endpoint, allowlist, etc.) |
+| `downloads` | Save bundle JSON to disk |
+| `scripting` | Inject the friendly recording banner into the active tab |
+| `offscreen` | Host MediaRecorder for voice narration (service workers can't) |
+| `tabs` | Identify the active tab to attach the debugger |
+| `<all_urls>` | The DevTools Protocol cannot be scoped per-host. The user-driven host filter trims what is stored. |
+
+## Bundle format
+
+Defined by `src/bundle/schema.ts` and mirrored at `../src/bundle/schema.ts` on the host. Both copies parse the same shared fixture (`../test/fixtures/bundle-example.json`) in CI.
+
+```jsonc
+{
+  "schemaVersion": "1",
+  "intent": "Onboard a new enterprise customer with first invoice",
+  "narrative": "...optional voice narration...",
+  "har": { "log": { "version": "1.2", "creator": {...}, "entries": [...] } },
+  "audio": null,
+  "metadata": {
+    "capturedBy": "specialist-extension",
+    "extensionVersion": "0.1.0",
+    "browser": "chrome/120",
+    "capturedAt": "2026-05-02T15:30:11.000Z",
+    "tabUrl": "https://dashboard.stripe.com/test/customers"
+  }
+}
+```
+
+Filename convention: `specialist-bundle-<iso8601>-<short-id>.json`.
+
+## Scrubbing
+
+`src/capture/scrub.ts` is a byte-for-byte port of `../src/capture/scrub.ts`. The shared fixture in `../test/fixtures/scrub-cases.json` runs against both copies in CI; if either drifts, the build fails. Scrubbing happens twice as defense-in-depth: once on each exchange as it leaves CDP, and again on bundle build.
+
+## POST endpoint contract
+
+When the user clicks "Submit to host", the extension POSTs the bundle JSON to:
+
+```
+POST {postEndpoint}/v1/bundles
+Content-Type: application/json
+Authorization: Bearer {postBearerToken}     (omitted if blank)
+```
+
+Server contract is documented in [`prompts/PLANS/browser-extension.md`](../prompts/PLANS/browser-extension.md) §7.2; the endpoint itself is out of scope for the extension. Errors surface as a popup error toast with a "Download instead" fallback.
+
+## Layout
+
+```
+browser-extension/
+  manifest.config.ts         # @crxjs manifest builder
+  vite.config.ts             # Vite + @crxjs + Vitest config
+  src/
+    background/              # Service worker: CDP attach, ingestion, scrub, persist
+      cdp/                   # CaptureAdapter interface + Chrome impl + reconstruct state machine
+    offscreen/               # Hidden DOM doc that hosts MediaRecorder + transcriber
+    popup/                   # React popup
+    options/                 # React options page
+    content/                 # Friendly recording banner overlay
+    capture/                 # scrub.ts (port), buffer.ts (port), har-emit.ts
+    bundle/                  # schema.ts (zod), build.ts, submit-download.ts, submit-post.ts
+    shared/                  # types, messages, config, logger
+  test/                      # Vitest unit tests + fixtures
+  vendor/                    # Whisper-tiny lazy-load slot (gitignored)
+```

--- a/browser-extension/manifest.config.ts
+++ b/browser-extension/manifest.config.ts
@@ -1,0 +1,34 @@
+import { defineManifest } from "@crxjs/vite-plugin";
+import pkg from "./package.json" with { type: "json" };
+
+export default defineManifest({
+  manifest_version: 3,
+  name: "Specialist Capture",
+  version: pkg.version,
+  description:
+    "Capture HTTP workflows for specialist-agent. Records network exchanges via the Chrome DevTools Protocol and bundles them into a portable JSON file (or POSTs to your synthesis host).",
+  background: {
+    service_worker: "src/background/main.ts",
+    type: "module",
+  },
+  action: {
+    default_popup: "src/popup/index.html",
+    default_title: "Specialist Capture",
+  },
+  options_page: "src/options/index.html",
+  permissions: [
+    "debugger",
+    "storage",
+    "downloads",
+    "scripting",
+    "offscreen",
+    "tabs",
+  ],
+  host_permissions: ["<all_urls>"],
+  web_accessible_resources: [
+    {
+      resources: ["vendor/whisper-tiny.wasm", "vendor/whisper.js", "src/content/banner.css"],
+      matches: ["<all_urls>"],
+    },
+  ],
+});

--- a/browser-extension/package-lock.json
+++ b/browser-extension/package-lock.json
@@ -1,0 +1,3584 @@
+{
+  "name": "specialist-extension",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "specialist-extension",
+      "version": "0.1.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "@crxjs/vite-plugin": "^2.0.0-beta.25",
+        "@types/chrome": "^0.0.270",
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.1",
+        "jsdom": "^24.1.0",
+        "typescript": "^5.6.0",
+        "vite": "^5.4.0",
+        "vitest": "^2.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@crxjs/vite-plugin": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@crxjs/vite-plugin/-/vite-plugin-2.4.0.tgz",
+      "integrity": "sha512-bDLdq0W2V1SkMQDJjrcYyjK9/uKtdl4joT7GRImcootCjZdKRiRYt+cv9z8tJoU/tK3o1lX48LTqN7JMsk5AQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^4.1.2",
+        "@webcomponents/custom-elements": "^1.5.0",
+        "acorn-walk": "^8.2.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.3.3",
+        "es-module-lexer": "^0.10.0",
+        "fast-glob": "^3.2.11",
+        "fs-extra": "^10.0.1",
+        "jsesc": "^3.0.2",
+        "magic-string": "^0.30.12",
+        "node-html-parser": "^7.0.2",
+        "pathe": "^2.0.1",
+        "picocolors": "^1.1.1",
+        "react-refresh": "^0.13.0",
+        "rollup": "2.79.2",
+        "rxjs": "7.5.7"
+      },
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chrome": {
+      "version": "0.0.270",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.270.tgz",
+      "integrity": "sha512-ADvkowV7YnJfycZZxL2brluZ6STGW+9oKG37B422UePf2PCXuFA/XdERI0T18wtuWPx0tmFeZqq6MOXVk1IC+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react/node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@webcomponents/custom-elements": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/custom-elements/-/custom-elements-1.6.0.tgz",
+      "integrity": "sha512-CqTpxOlUCPWRNUPZDxT5v2NnHXA4oox612iUGnmTUGQFhZ1Gkj8kirtl/2wcF6MqX7+PqqicZzOCBKKfIn0dww==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.25",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
+      "integrity": "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.349",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
+      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.10.5.tgz",
+      "integrity": "sha512-+7IwY/kiGAacQfY+YBhKMvEmyAJnw5grTUgjG85Pe7vcUI/6b7pZjZG8nQ7+48YhzEAEqrEgD2dCz/JIK+AYvw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.1.0.tgz",
+      "integrity": "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
+      "integrity": "sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "specialist-extension",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Browser extension capture surface for specialist-agent. Captures HTTP workflows via the Chrome DevTools Protocol and emits a HAR-1.2 bundle with optional voice narration.",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@crxjs/vite-plugin": "^2.0.0-beta.25",
+    "@types/chrome": "^0.0.270",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "jsdom": "^24.1.0",
+    "typescript": "^5.6.0",
+    "vite": "^5.4.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/browser-extension/src/background/cdp/adapter.ts
+++ b/browser-extension/src/background/cdp/adapter.ts
@@ -1,0 +1,13 @@
+// CaptureAdapter abstracts the capture mechanism so v1.1 can swap in a
+// Firefox `webRequest.filterResponseData`-based implementation without
+// touching the rest of the background pipeline.
+
+import type { HttpExchange } from "../../shared/types.js";
+
+export interface CaptureAdapter {
+  attach(tabId: number): Promise<void>;
+  detach(tabId: number): Promise<void>;
+  onExchange(cb: (exchange: Omit<HttpExchange, "index">) => void): void;
+  onError(cb: (e: { code: string; detail: string }) => void): void;
+  onNavigation(cb: (url: string) => void): void;
+}

--- a/browser-extension/src/background/cdp/chrome-debugger.ts
+++ b/browser-extension/src/background/cdp/chrome-debugger.ts
@@ -1,0 +1,162 @@
+// Chrome implementation of CaptureAdapter — wires `chrome.debugger`'s
+// Network domain through to `CdpReconstructor`.
+
+import { logger } from "../../shared/logger.js";
+import type { HttpExchange } from "../../shared/types.js";
+import type { CaptureAdapter } from "./adapter.js";
+import type {
+  DataReceived,
+  GetResponseBodyResult,
+  LoadingFailed,
+  LoadingFinished,
+  RequestWillBeSent,
+  RequestWillBeSentExtraInfo,
+  ResponseReceived,
+  ResponseReceivedExtraInfo,
+} from "./events.js";
+import { CdpReconstructor } from "./reconstruct.js";
+
+const CDP_VERSION = "1.3";
+
+export interface ChromeDebuggerAdapterOptions {
+  bodyMaxBytes: number;
+}
+
+export class ChromeDebuggerAdapter implements CaptureAdapter {
+  private exchangeCb: ((e: Omit<HttpExchange, "index">) => void) | null = null;
+  private errorCb: ((e: { code: string; detail: string }) => void) | null = null;
+  private navigationCb: ((url: string) => void) | null = null;
+  private attachedTabId: number | null = null;
+  private reconstructor: CdpReconstructor;
+  private detachListener = this.handleDetach.bind(this);
+  private eventListener = this.handleEvent.bind(this);
+  private navListener: ((details: chrome.webNavigation.WebNavigationFramedCallbackDetails) => void) | null = null;
+
+  constructor(opts: ChromeDebuggerAdapterOptions) {
+    this.reconstructor = new CdpReconstructor({
+      bodyMaxBytes: opts.bodyMaxBytes,
+      getResponseBody: (requestId) => this.getResponseBody(requestId),
+      onExchange: (e) => this.exchangeCb?.(e),
+      onError: (e) => this.errorCb?.(e),
+    });
+  }
+
+  async attach(tabId: number): Promise<void> {
+    if (this.attachedTabId !== null) {
+      throw new Error("ChromeDebuggerAdapter already attached");
+    }
+    this.attachedTabId = tabId;
+
+    chrome.debugger.onEvent.addListener(this.eventListener);
+    chrome.debugger.onDetach.addListener(this.detachListener);
+
+    try {
+      await chrome.debugger.attach({ tabId }, CDP_VERSION);
+      await chrome.debugger.sendCommand({ tabId }, "Network.enable", {});
+    } catch (err) {
+      this.attachedTabId = null;
+      chrome.debugger.onEvent.removeListener(this.eventListener);
+      chrome.debugger.onDetach.removeListener(this.detachListener);
+      const detail = (err as Error).message;
+      this.errorCb?.({
+        code: detail.toLowerCase().includes("devtools") ? "devtools_open" : "cdp_attach_failed",
+        detail,
+      });
+      throw err;
+    }
+  }
+
+  async detach(tabId: number): Promise<void> {
+    if (this.attachedTabId !== tabId) return;
+    chrome.debugger.onEvent.removeListener(this.eventListener);
+    chrome.debugger.onDetach.removeListener(this.detachListener);
+    if (this.navListener && chrome.webNavigation?.onCommitted) {
+      chrome.webNavigation.onCommitted.removeListener(this.navListener);
+      this.navListener = null;
+    }
+    try {
+      await chrome.debugger.detach({ tabId });
+    } catch (err) {
+      logger.warn("debugger detach failed", err);
+    }
+    this.attachedTabId = null;
+    this.reconstructor.reset();
+  }
+
+  onExchange(cb: (e: Omit<HttpExchange, "index">) => void): void {
+    this.exchangeCb = cb;
+  }
+
+  onError(cb: (e: { code: string; detail: string }) => void): void {
+    this.errorCb = cb;
+  }
+
+  onNavigation(cb: (url: string) => void): void {
+    this.navigationCb = cb;
+    if (this.attachedTabId === null) return;
+    if (!chrome.webNavigation?.onCommitted) return;
+    const tabId = this.attachedTabId;
+    this.navListener = (details) => {
+      if (details.tabId !== tabId || details.frameId !== 0) return;
+      this.reconstructor.emitNavigationBoundary(details.url);
+      this.navigationCb?.(details.url);
+    };
+    chrome.webNavigation.onCommitted.addListener(this.navListener);
+  }
+
+  private handleDetach(source: chrome.debugger.Debuggee, reason: string): void {
+    if (source.tabId !== this.attachedTabId) return;
+    this.errorCb?.({ code: reason === "target_closed" ? "tab_closed" : "cdp_attach_failed", detail: reason });
+    this.attachedTabId = null;
+    this.reconstructor.reset();
+  }
+
+  private handleEvent(
+    source: chrome.debugger.Debuggee,
+    method: string,
+    params?: unknown,
+  ): void {
+    if (source.tabId !== this.attachedTabId) return;
+    const p = params as Record<string, unknown> | undefined;
+    if (!p) return;
+    switch (method) {
+      case "Network.requestWillBeSent":
+        this.reconstructor.onRequestWillBeSent(p as unknown as RequestWillBeSent);
+        break;
+      case "Network.requestWillBeSentExtraInfo":
+        this.reconstructor.onRequestWillBeSentExtraInfo(p as unknown as RequestWillBeSentExtraInfo);
+        break;
+      case "Network.responseReceived":
+        this.reconstructor.onResponseReceived(p as unknown as ResponseReceived);
+        break;
+      case "Network.responseReceivedExtraInfo":
+        this.reconstructor.onResponseReceivedExtraInfo(p as unknown as ResponseReceivedExtraInfo);
+        break;
+      case "Network.dataReceived":
+        this.reconstructor.onDataReceived(p as unknown as DataReceived);
+        break;
+      case "Network.loadingFinished":
+        void this.reconstructor.onLoadingFinished(p as unknown as LoadingFinished);
+        break;
+      case "Network.loadingFailed":
+        this.reconstructor.onLoadingFailed(p as unknown as LoadingFailed);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private async getResponseBody(requestId: string): Promise<GetResponseBodyResult | null> {
+    if (this.attachedTabId === null) return null;
+    try {
+      const result = await chrome.debugger.sendCommand(
+        { tabId: this.attachedTabId },
+        "Network.getResponseBody",
+        { requestId },
+      );
+      return result as GetResponseBodyResult;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/browser-extension/src/background/cdp/events.ts
+++ b/browser-extension/src/background/cdp/events.ts
@@ -1,0 +1,80 @@
+// Subset of Chrome DevTools Protocol "Network" event payloads we use.
+// Field types lifted from the DevTools Protocol viewer; only the ones we
+// actually read are typed.
+
+export interface CdpRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  postData?: string;
+  hasPostData?: boolean;
+}
+
+export interface CdpResponse {
+  url: string;
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  mimeType: string;
+  encodedDataLength?: number;
+}
+
+export interface RequestWillBeSent {
+  requestId: string;
+  loaderId: string;
+  documentURL: string;
+  request: CdpRequest;
+  timestamp: number;
+  wallTime: number;
+  initiator?: { type: string };
+  redirectResponse?: CdpResponse;
+  type?: string;
+  frameId?: string;
+}
+
+export interface RequestWillBeSentExtraInfo {
+  requestId: string;
+  headers: Record<string, string>;
+  associatedCookies?: unknown[];
+}
+
+export interface ResponseReceived {
+  requestId: string;
+  loaderId: string;
+  timestamp: number;
+  type: string;
+  response: CdpResponse;
+  frameId?: string;
+}
+
+export interface ResponseReceivedExtraInfo {
+  requestId: string;
+  headers: Record<string, string>;
+  statusCode?: number;
+}
+
+export interface DataReceived {
+  requestId: string;
+  timestamp: number;
+  dataLength: number;
+  encodedDataLength: number;
+}
+
+export interface LoadingFinished {
+  requestId: string;
+  timestamp: number;
+  encodedDataLength: number;
+}
+
+export interface LoadingFailed {
+  requestId: string;
+  timestamp: number;
+  type: string;
+  errorText: string;
+  canceled?: boolean;
+}
+
+export interface GetResponseBodyResult {
+  body: string;
+  base64Encoded: boolean;
+}

--- a/browser-extension/src/background/cdp/reconstruct.ts
+++ b/browser-extension/src/background/cdp/reconstruct.ts
@@ -1,0 +1,300 @@
+// Pending-exchange state machine. Folds the stream of CDP events into
+// completed `HttpExchange` records. Pure logic, no chrome.* calls — that
+// makes it trivially unit-testable from a recorded JSONL fixture.
+
+import type { HttpExchange } from "../../shared/types.js";
+import type {
+  DataReceived,
+  GetResponseBodyResult,
+  LoadingFailed,
+  LoadingFinished,
+  RequestWillBeSent,
+  RequestWillBeSentExtraInfo,
+  ResponseReceived,
+  ResponseReceivedExtraInfo,
+} from "./events.js";
+
+interface PendingExchange {
+  requestId: string;
+  startedAt: string;
+  request: {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    body: unknown;
+    timestamp: string;
+  };
+  response?: {
+    status: number;
+    headers: Record<string, string>;
+    mimeType: string;
+    durationMs: number;
+  };
+  startTimestamp: number;
+  bytesReceived: number;
+}
+
+export interface ReconstructorOptions {
+  bodyMaxBytes: number;
+  /**
+   * Async getter for the response body. Wraps
+   * `chrome.debugger.sendCommand("Network.getResponseBody", ...)`.
+   * Returns null if the body is not available (e.g. failed request).
+   */
+  getResponseBody: (requestId: string) => Promise<GetResponseBodyResult | null>;
+  onExchange: (exchange: Omit<HttpExchange, "index">) => void;
+  onError?: (e: { code: string; detail: string }) => void;
+}
+
+const RACE_BUFFER_MS = 50;
+
+export class CdpReconstructor {
+  private pending = new Map<string, PendingExchange>();
+  private extraReqInfo = new Map<string, RequestWillBeSentExtraInfo>();
+  private extraResInfo = new Map<string, ResponseReceivedExtraInfo>();
+
+  constructor(private readonly opts: ReconstructorOptions) {}
+
+  onRequestWillBeSent(ev: RequestWillBeSent): void {
+    if (ev.redirectResponse) {
+      const prior = this.pending.get(ev.requestId);
+      if (prior) {
+        prior.response = {
+          status: ev.redirectResponse.status,
+          headers: { ...ev.redirectResponse.headers },
+          mimeType: ev.redirectResponse.mimeType,
+          durationMs: Math.max(0, (ev.timestamp - prior.startTimestamp) * 1000),
+        };
+        this.opts.onExchange({
+          request: prior.request,
+          response: {
+            status: prior.response.status,
+            headers: prior.response.headers,
+            body: null,
+            durationMs: prior.response.durationMs,
+          },
+        });
+      }
+      this.pending.delete(ev.requestId);
+    }
+
+    const merged = mergeHeaders(ev.request.headers, this.extraReqInfo.get(ev.requestId)?.headers);
+    this.extraReqInfo.delete(ev.requestId);
+
+    this.pending.set(ev.requestId, {
+      requestId: ev.requestId,
+      startedAt: new Date(ev.wallTime * 1000).toISOString(),
+      startTimestamp: ev.timestamp,
+      bytesReceived: 0,
+      request: {
+        method: ev.request.method.toUpperCase(),
+        url: ev.request.url,
+        headers: merged,
+        body: parseRequestBody(ev.request.postData, merged),
+        timestamp: new Date(ev.wallTime * 1000).toISOString(),
+      },
+    });
+  }
+
+  onRequestWillBeSentExtraInfo(ev: RequestWillBeSentExtraInfo): void {
+    const pending = this.pending.get(ev.requestId);
+    if (pending) {
+      pending.request.headers = mergeHeaders(pending.request.headers, ev.headers);
+    } else {
+      this.extraReqInfo.set(ev.requestId, ev);
+      setTimeout(() => this.extraReqInfo.delete(ev.requestId), RACE_BUFFER_MS);
+    }
+  }
+
+  onResponseReceived(ev: ResponseReceived): void {
+    const pending = this.pending.get(ev.requestId);
+    if (!pending) return;
+    const merged = mergeHeaders(ev.response.headers, this.extraResInfo.get(ev.requestId)?.headers);
+    this.extraResInfo.delete(ev.requestId);
+    pending.response = {
+      status: ev.response.status,
+      headers: merged,
+      mimeType: ev.response.mimeType,
+      durationMs: Math.max(0, (ev.timestamp - pending.startTimestamp) * 1000),
+    };
+  }
+
+  onResponseReceivedExtraInfo(ev: ResponseReceivedExtraInfo): void {
+    const pending = this.pending.get(ev.requestId);
+    if (pending?.response) {
+      pending.response.headers = mergeHeaders(pending.response.headers, ev.headers);
+    } else {
+      this.extraResInfo.set(ev.requestId, ev);
+      setTimeout(() => this.extraResInfo.delete(ev.requestId), RACE_BUFFER_MS);
+    }
+  }
+
+  onDataReceived(ev: DataReceived): void {
+    const pending = this.pending.get(ev.requestId);
+    if (pending) pending.bytesReceived += ev.encodedDataLength || ev.dataLength;
+  }
+
+  async onLoadingFinished(ev: LoadingFinished): Promise<void> {
+    const pending = this.pending.get(ev.requestId);
+    if (!pending || !pending.response) {
+      this.pending.delete(ev.requestId);
+      return;
+    }
+
+    let body: unknown = null;
+    try {
+      const result = await this.opts.getResponseBody(ev.requestId);
+      if (result) {
+        body = decodeBody(result, pending.response.mimeType, this.opts.bodyMaxBytes);
+      }
+    } catch (err) {
+      this.opts.onError?.({
+        code: "get_response_body_failed",
+        detail: (err as Error).message,
+      });
+    }
+
+    pending.response.durationMs = Math.max(0, (ev.timestamp - pending.startTimestamp) * 1000);
+    this.opts.onExchange({
+      request: pending.request,
+      response: {
+        status: pending.response.status,
+        headers: pending.response.headers,
+        body,
+        durationMs: pending.response.durationMs,
+      },
+    });
+    this.pending.delete(ev.requestId);
+  }
+
+  onLoadingFailed(ev: LoadingFailed): void {
+    const pending = this.pending.get(ev.requestId);
+    if (!pending) return;
+    this.opts.onExchange({
+      request: pending.request,
+      response: {
+        status: 0,
+        headers: { "x-extension-error": ev.errorText || "loading_failed" },
+        body: null,
+        durationMs: Math.max(0, (ev.timestamp - pending.startTimestamp) * 1000),
+      },
+    });
+    this.pending.delete(ev.requestId);
+  }
+
+  /**
+   * Synthesize a navigation boundary so post-hoc readers can spot when
+   * the active tab navigated mid-capture.
+   */
+  emitNavigationBoundary(url: string): void {
+    this.opts.onExchange({
+      request: {
+        method: "NAVIGATE",
+        url,
+        headers: {},
+        body: null,
+        timestamp: new Date().toISOString(),
+      },
+      response: {
+        status: 0,
+        headers: {},
+        body: null,
+        durationMs: 0,
+      },
+    });
+  }
+
+  reset(): void {
+    this.pending.clear();
+    this.extraReqInfo.clear();
+    this.extraResInfo.clear();
+  }
+}
+
+function mergeHeaders(
+  base: Record<string, string>,
+  extra: Record<string, string> | undefined,
+): Record<string, string> {
+  if (!extra) return { ...base };
+  const out: Record<string, string> = { ...base };
+  for (const [k, v] of Object.entries(extra)) out[k] = v;
+  return out;
+}
+
+function parseRequestBody(postData: string | undefined, headers: Record<string, string>): unknown {
+  if (!postData) return null;
+  const ct = lookupHeader(headers, "content-type") ?? "";
+  if (ct.includes("application/json")) {
+    try {
+      return JSON.parse(postData);
+    } catch {
+      return postData;
+    }
+  }
+  return postData;
+}
+
+function lookupHeader(h: Record<string, string>, name: string): string | undefined {
+  const lower = name.toLowerCase();
+  for (const [k, v] of Object.entries(h)) {
+    if (k.toLowerCase() === lower) return v;
+  }
+  return undefined;
+}
+
+interface BinaryMarker {
+  __binary: true;
+  mediaType: string;
+  length: number;
+}
+
+function decodeBody(
+  result: GetResponseBodyResult,
+  mimeType: string,
+  bodyMaxBytes: number,
+): unknown {
+  const { body, base64Encoded } = result;
+  if (base64Encoded && !looksTextual(mimeType)) {
+    const length = Math.floor((body.length * 3) / 4);
+    const marker: BinaryMarker = { __binary: true, mediaType: mimeType, length };
+    return marker;
+  }
+
+  let text = base64Encoded ? safeAtob(body) : body;
+  if (text.length > bodyMaxBytes) {
+    text = text.slice(0, bodyMaxBytes);
+    if (mimeType.includes("application/json")) {
+      return { _truncated: true, _preview: text.slice(0, 1024) };
+    }
+    return text + "\n[_truncated: true]";
+  }
+
+  if (mimeType.includes("application/json")) {
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+  return text;
+}
+
+function looksTextual(mimeType: string): boolean {
+  const m = mimeType.toLowerCase();
+  return (
+    m.startsWith("text/") ||
+    m.includes("json") ||
+    m.includes("xml") ||
+    m.includes("javascript") ||
+    m.includes("x-www-form-urlencoded") ||
+    m.includes("event-stream")
+  );
+}
+
+function safeAtob(s: string): string {
+  try {
+    return atob(s);
+  } catch {
+    return "";
+  }
+}

--- a/browser-extension/src/background/main.ts
+++ b/browser-extension/src/background/main.ts
@@ -1,0 +1,61 @@
+// Service worker entry. Activated on user interaction (popup click,
+// installation, debugger event). Owns one CaptureSessionRunner at a
+// time; the router is the single dispatch surface.
+
+import { loadConfig, DEFAULT_CONFIG } from "../shared/config.js";
+import { logger } from "../shared/logger.js";
+import { installRouter } from "./router.js";
+import { CaptureSessionRunner } from "./session.js";
+import { loadCapture } from "./storage.js";
+
+let session: CaptureSessionRunner | null = null;
+
+const VERSION = chrome.runtime.getManifest().version;
+
+installRouter({
+  getSession: () => session,
+  setSession: (s) => {
+    session = s;
+  },
+  createSession: async (tabId, _recordAudio) => {
+    const cfg = await loadConfig().catch(() => DEFAULT_CONFIG);
+    let tabUrl: string | undefined;
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      tabUrl = tab.url;
+    } catch {
+      /* tab may be gone */
+    }
+    return new CaptureSessionRunner(
+      {
+        tabId,
+        ...(tabUrl ? { tabUrl } : {}),
+        recordAudio: _recordAudio,
+        bodyMaxBytes: cfg.bodyMaxBytes,
+        hostFilterMode: cfg.hostFilterMode,
+        hostAllowlist: cfg.hostAllowlist,
+        extensionVersion: VERSION,
+        browser: detectBrowser(),
+      },
+      {},
+    );
+  },
+});
+
+chrome.runtime.onInstalled.addListener(() => {
+  logger.info("specialist-extension installed", VERSION);
+});
+
+chrome.runtime.onStartup.addListener(async () => {
+  const persisted = await loadCapture();
+  if (persisted) {
+    logger.warn("found persisted capture from a previous session — discarding (rehydrate is v1.1)");
+  }
+});
+
+function detectBrowser(): string {
+  const ua = navigator.userAgent;
+  const m = ua.match(/Chrom[ei]\w+\/(\d+)/);
+  if (m) return `chrome/${m[1]}`;
+  return "chrome/unknown";
+}

--- a/browser-extension/src/background/offscreen-control.ts
+++ b/browser-extension/src/background/offscreen-control.ts
@@ -1,0 +1,25 @@
+// MV3 service workers cannot use getUserMedia/MediaRecorder. We open an
+// offscreen document — a hidden DOM context — that hosts the recorder
+// and posts audio + transcript chunks back over chrome.runtime messages.
+
+const OFFSCREEN_URL = "src/offscreen/recorder.html";
+
+export async function ensureOffscreen(): Promise<void> {
+  const existing = await chrome.offscreen.hasDocument?.();
+  if (existing) return;
+  await chrome.offscreen.createDocument({
+    url: OFFSCREEN_URL,
+    reasons: [chrome.offscreen.Reason.USER_MEDIA],
+    justification: "Record voice narration accompanying the captured workflow.",
+  });
+}
+
+export async function closeOffscreen(): Promise<void> {
+  const has = await chrome.offscreen.hasDocument?.();
+  if (!has) return;
+  try {
+    await chrome.offscreen.closeDocument();
+  } catch {
+    /* already closed */
+  }
+}

--- a/browser-extension/src/background/router.ts
+++ b/browser-extension/src/background/router.ts
@@ -1,0 +1,189 @@
+// Single-place dispatch for chrome.runtime.sendMessage. Keeping this in
+// one file means popup, options, and offscreen all see the same wire
+// shape via `ClientMessage`.
+
+import { loadConfig, saveConfig } from "../shared/config.js";
+import type { ClientMessage, ServerMessage } from "../shared/messages.js";
+import { POPUP_STATS_PORT } from "../shared/messages.js";
+import { logger } from "../shared/logger.js";
+import type { CaptureSessionRunner } from "./session.js";
+import { ensureOffscreen, closeOffscreen } from "./offscreen-control.js";
+import { submitDownload } from "../bundle/submit-download.js";
+import { submitPost } from "../bundle/submit-post.js";
+
+export interface RouterDeps {
+  getSession: () => CaptureSessionRunner | null;
+  setSession: (s: CaptureSessionRunner | null) => void;
+  createSession: (tabId: number, recordAudio: boolean) => Promise<CaptureSessionRunner>;
+}
+
+export function installRouter(deps: RouterDeps): void {
+  chrome.runtime.onMessage.addListener((msg: ClientMessage, _sender, sendResponse) => {
+    void handle(msg, deps).then(sendResponse).catch((err) => {
+      logger.error("router error", err);
+      sendResponse({ ok: false, error: (err as Error).message });
+    });
+    return true;
+  });
+
+  chrome.runtime.onConnect.addListener((port) => {
+    if (port.name !== POPUP_STATS_PORT) return;
+    const session = deps.getSession();
+    const send = (m: ServerMessage) => {
+      try {
+        port.postMessage(m);
+      } catch {
+        /* port closed */
+      }
+    };
+    if (session) {
+      send({ type: "BG_TO_POPUP_CAPTURE_STATS", stats: session.snapshot() });
+      session.setEvents({
+        onStats: (stats) => send({ type: "BG_TO_POPUP_CAPTURE_STATS", stats }),
+        onError: (e) => send({ type: "BG_TO_POPUP_ERROR", code: e.code as never, detail: e.detail }),
+      });
+    }
+    port.onDisconnect.addListener(() => {
+      const s = deps.getSession();
+      s?.setEvents({});
+    });
+  });
+}
+
+async function handle(msg: ClientMessage, deps: RouterDeps): Promise<unknown> {
+  switch (msg.type) {
+    case "POPUP_TO_BG_START_RECORDING": {
+      if (deps.getSession()) throw new Error("a recording is already in progress");
+      const session = await deps.createSession(msg.tabId, msg.recordAudio);
+      deps.setSession(session);
+      await session.start();
+      if (msg.recordAudio) {
+        await ensureOffscreen();
+        const cfg = await loadConfig();
+        await chrome.runtime.sendMessage({
+          type: "BG_TO_OFFSCREEN_START_RECORDING",
+          mimeType: "audio/webm;codecs=opus",
+          transcriber: cfg.transcriber,
+        } satisfies ServerMessage);
+      }
+      await chrome.scripting
+        .executeScript({
+          target: { tabId: msg.tabId },
+          files: ["src/content/banner.js"],
+        })
+        .catch(() => {
+          /* injection may fail on chrome:// pages — non-fatal */
+        });
+      return { ok: true, sessionId: session.snapshot().startedAt };
+    }
+    case "POPUP_TO_BG_STOP_RECORDING": {
+      const session = deps.getSession();
+      if (!session) throw new Error("no active session");
+      await chrome.runtime
+        .sendMessage({ type: "BG_TO_OFFSCREEN_STOP_RECORDING" } satisfies ServerMessage)
+        .catch(() => {
+          /* offscreen may not be open if recordAudio was false */
+        });
+      await session.stop();
+      return { ok: true, stats: session.snapshot() };
+    }
+    case "POPUP_TO_BG_GET_SNAPSHOT": {
+      const session = deps.getSession();
+      if (!session) return { active: false };
+      return {
+        active: true,
+        stats: session.snapshot(),
+        intent: session.intentText(),
+        narrative: session.narrativeText(),
+      };
+    }
+    case "POPUP_TO_BG_UPDATE_INTENT": {
+      const session = deps.getSession();
+      if (!session) throw new Error("no active session");
+      session.setIntent(msg.intent, msg.narrative);
+      return { ok: true };
+    }
+    case "POPUP_TO_BG_FILTER_HOST": {
+      const session = deps.getSession();
+      if (!session) throw new Error("no active session");
+      session.setHostFilter(msg.hostPattern);
+      return { ok: true };
+    }
+    case "POPUP_TO_BG_BUILD_BUNDLE": {
+      const session = deps.getSession();
+      if (!session) throw new Error("no active session");
+      const bundle = session.buildBundle(msg.includeAudio);
+      return { ok: true, bundle };
+    }
+    case "POPUP_TO_BG_SUBMIT_DOWNLOAD": {
+      const session = deps.getSession();
+      if (!session) throw new Error("no active session");
+      const bundle = session.buildBundle(true);
+      const result = await submitDownload(bundle);
+      return { ok: true, ...result };
+    }
+    case "POPUP_TO_BG_SUBMIT_POST": {
+      const session = deps.getSession();
+      if (!session) throw new Error("no active session");
+      const bundle = session.buildBundle(true);
+      const cfg = await loadConfig();
+      const result = await submitPost(bundle, cfg);
+      return result;
+    }
+    case "POPUP_TO_BG_DISCARD": {
+      const session = deps.getSession();
+      if (session) await session.discard();
+      deps.setSession(null);
+      await closeOffscreen();
+      return { ok: true };
+    }
+    case "OPTIONS_TO_BG_SET_CONFIG": {
+      await saveConfig(msg.config);
+      return { ok: true };
+    }
+    case "OFFSCREEN_TO_BG_AUDIO_CHUNK": {
+      // v1: we keep only the final blob, so per-chunk messages are
+      // informational. Forward to the popup if it wants a level meter.
+      return { ok: true };
+    }
+    case "OFFSCREEN_TO_BG_TRANSCRIPT_PARTIAL": {
+      const session = deps.getSession();
+      if (!session) return { ok: true };
+      const existing = session.intentText();
+      const next = msg.isFinal ? mergeTranscript(existing, msg.text) : existing;
+      session.setIntent(next, msg.isFinal ? appendNarrative(session.narrativeText(), msg.text) : session.narrativeText());
+      return { ok: true };
+    }
+    case "OFFSCREEN_TO_BG_RECORDING_STOPPED": {
+      const session = deps.getSession();
+      if (!session) return { ok: true };
+      if (msg.finalAudio) {
+        session.setAudio({
+          mimeType: msg.mimeType,
+          bytes: msg.finalAudio,
+          durationMs: msg.durationMs,
+        });
+      }
+      await closeOffscreen();
+      return { ok: true };
+    }
+    default:
+      throw new Error(`unknown message type: ${(msg as { type: string }).type}`);
+  }
+}
+
+function mergeTranscript(existing: string, finalText: string): string {
+  if (!existing) return firstSentence(finalText);
+  return existing;
+}
+
+function appendNarrative(existing: string, chunk: string): string {
+  if (!existing) return chunk;
+  if (existing.endsWith(chunk)) return existing;
+  return `${existing} ${chunk}`.trim();
+}
+
+function firstSentence(text: string): string {
+  const m = text.match(/^[^.!?]+[.!?]/);
+  return (m ? m[0] : text).trim().slice(0, 200);
+}

--- a/browser-extension/src/background/router.ts
+++ b/browser-extension/src/background/router.ts
@@ -1,20 +1,43 @@
 // Single-place dispatch for chrome.runtime.sendMessage. Keeping this in
 // one file means popup, options, and offscreen all see the same wire
 // shape via `ClientMessage`.
+//
+// Auto-submit policy: when the user clicks Stop, the bundle is built
+// and POSTed to the configured backend. If no endpoint is configured or
+// the POST fails, the bundle falls back to a local download so no
+// recording is ever silently dropped on the floor.
 
-import { loadConfig, saveConfig } from "../shared/config.js";
-import type { ClientMessage, ServerMessage } from "../shared/messages.js";
+import { loadConfig, saveConfig, type ExtensionConfig } from "../shared/config.js";
+import type { ClientMessage, ServerMessage, SubmitResult } from "../shared/messages.js";
 import { POPUP_STATS_PORT } from "../shared/messages.js";
 import { logger } from "../shared/logger.js";
 import type { CaptureSessionRunner } from "./session.js";
 import { ensureOffscreen, closeOffscreen } from "./offscreen-control.js";
 import { submitDownload } from "../bundle/submit-download.js";
 import { submitPost } from "../bundle/submit-post.js";
+import type { Bundle } from "../bundle/schema.js";
+
+const AUDIO_FINALIZE_TIMEOUT_MS = 5_000;
 
 export interface RouterDeps {
   getSession: () => CaptureSessionRunner | null;
   setSession: (s: CaptureSessionRunner | null) => void;
   createSession: (tabId: number, recordAudio: boolean) => Promise<CaptureSessionRunner>;
+}
+
+let lastSubmitResult: SubmitResult | null = null;
+let lastBuiltBundle: Bundle | null = null;
+
+const popupPorts = new Set<chrome.runtime.Port>();
+
+function broadcastToPopup(m: ServerMessage): void {
+  for (const port of popupPorts) {
+    try {
+      port.postMessage(m);
+    } catch {
+      /* port closed */
+    }
+  }
 }
 
 export function installRouter(deps: RouterDeps): void {
@@ -28,24 +51,22 @@ export function installRouter(deps: RouterDeps): void {
 
   chrome.runtime.onConnect.addListener((port) => {
     if (port.name !== POPUP_STATS_PORT) return;
+    popupPorts.add(port);
     const session = deps.getSession();
-    const send = (m: ServerMessage) => {
-      try {
-        port.postMessage(m);
-      } catch {
-        /* port closed */
-      }
-    };
     if (session) {
-      send({ type: "BG_TO_POPUP_CAPTURE_STATS", stats: session.snapshot() });
+      port.postMessage({ type: "BG_TO_POPUP_CAPTURE_STATS", stats: session.snapshot() } satisfies ServerMessage);
       session.setEvents({
-        onStats: (stats) => send({ type: "BG_TO_POPUP_CAPTURE_STATS", stats }),
-        onError: (e) => send({ type: "BG_TO_POPUP_ERROR", code: e.code as never, detail: e.detail }),
+        onStats: (stats) => broadcastToPopup({ type: "BG_TO_POPUP_CAPTURE_STATS", stats }),
+        onError: (e) => broadcastToPopup({ type: "BG_TO_POPUP_ERROR", code: e.code as never, detail: e.detail }),
       });
     }
+    if (lastSubmitResult) {
+      port.postMessage({ type: "BG_TO_POPUP_SUBMIT_RESULT", result: lastSubmitResult } satisfies ServerMessage);
+    }
     port.onDisconnect.addListener(() => {
+      popupPorts.delete(port);
       const s = deps.getSession();
-      s?.setEvents({});
+      if (popupPorts.size === 0) s?.setEvents({});
     });
   });
 }
@@ -54,6 +75,8 @@ async function handle(msg: ClientMessage, deps: RouterDeps): Promise<unknown> {
   switch (msg.type) {
     case "POPUP_TO_BG_START_RECORDING": {
       if (deps.getSession()) throw new Error("a recording is already in progress");
+      lastSubmitResult = null;
+      lastBuiltBundle = null;
       const session = await deps.createSession(msg.tabId, msg.recordAudio);
       deps.setSession(session);
       await session.start();
@@ -79,22 +102,36 @@ async function handle(msg: ClientMessage, deps: RouterDeps): Promise<unknown> {
     case "POPUP_TO_BG_STOP_RECORDING": {
       const session = deps.getSession();
       if (!session) throw new Error("no active session");
+
+      const audioWait = session.opts.recordAudio ? session.awaitAudio(AUDIO_FINALIZE_TIMEOUT_MS) : Promise.resolve();
       await chrome.runtime
         .sendMessage({ type: "BG_TO_OFFSCREEN_STOP_RECORDING" } satisfies ServerMessage)
         .catch(() => {
           /* offscreen may not be open if recordAudio was false */
         });
       await session.stop();
-      return { ok: true, stats: session.snapshot() };
+      await audioWait;
+
+      broadcastToPopup({ type: "BG_TO_POPUP_SUBMIT_PENDING" });
+      const cfg = await loadConfig();
+      const bundle = session.buildBundle(true);
+      lastBuiltBundle = bundle;
+      const result = await autoSubmit(bundle, cfg);
+      lastSubmitResult = result;
+      broadcastToPopup({ type: "BG_TO_POPUP_SUBMIT_RESULT", result });
+      return { ok: true, result, stats: session.snapshot() };
     }
     case "POPUP_TO_BG_GET_SNAPSHOT": {
       const session = deps.getSession();
-      if (!session) return { active: false };
+      if (!session) {
+        return { active: false, lastSubmitResult };
+      }
       return {
         active: true,
         stats: session.snapshot(),
         intent: session.intentText(),
         narrative: session.narrativeText(),
+        lastSubmitResult,
       };
     }
     case "POPUP_TO_BG_UPDATE_INTENT": {
@@ -115,25 +152,36 @@ async function handle(msg: ClientMessage, deps: RouterDeps): Promise<unknown> {
       const bundle = session.buildBundle(msg.includeAudio);
       return { ok: true, bundle };
     }
-    case "POPUP_TO_BG_SUBMIT_DOWNLOAD": {
-      const session = deps.getSession();
-      if (!session) throw new Error("no active session");
-      const bundle = session.buildBundle(true);
-      const result = await submitDownload(bundle);
-      return { ok: true, ...result };
+    case "POPUP_TO_BG_DOWNLOAD_FALLBACK": {
+      const bundle = lastBuiltBundle ?? deps.getSession()?.buildBundle(true);
+      if (!bundle) throw new Error("no bundle available — start a new recording");
+      const dl = await submitDownload(bundle);
+      const result: SubmitResult = {
+        kind: "downloaded",
+        filename: dl.filename,
+        bytes: dl.bytes,
+        reason: "post_failed",
+      };
+      lastSubmitResult = result;
+      broadcastToPopup({ type: "BG_TO_POPUP_SUBMIT_RESULT", result });
+      return { ok: true, result };
     }
-    case "POPUP_TO_BG_SUBMIT_POST": {
-      const session = deps.getSession();
-      if (!session) throw new Error("no active session");
-      const bundle = session.buildBundle(true);
+    case "POPUP_TO_BG_RETRY_SUBMIT": {
+      const bundle = lastBuiltBundle ?? deps.getSession()?.buildBundle(true);
+      if (!bundle) throw new Error("no bundle available — start a new recording");
+      broadcastToPopup({ type: "BG_TO_POPUP_SUBMIT_PENDING" });
       const cfg = await loadConfig();
-      const result = await submitPost(bundle, cfg);
-      return result;
+      const result = await autoSubmit(bundle, cfg);
+      lastSubmitResult = result;
+      broadcastToPopup({ type: "BG_TO_POPUP_SUBMIT_RESULT", result });
+      return { ok: true, result };
     }
     case "POPUP_TO_BG_DISCARD": {
       const session = deps.getSession();
       if (session) await session.discard();
       deps.setSession(null);
+      lastSubmitResult = null;
+      lastBuiltBundle = null;
       await closeOffscreen();
       return { ok: true };
     }
@@ -156,19 +204,64 @@ async function handle(msg: ClientMessage, deps: RouterDeps): Promise<unknown> {
     }
     case "OFFSCREEN_TO_BG_RECORDING_STOPPED": {
       const session = deps.getSession();
-      if (!session) return { ok: true };
+      if (!session) {
+        await closeOffscreen();
+        return { ok: true };
+      }
       if (msg.finalAudio) {
         session.setAudio({
           mimeType: msg.mimeType,
           bytes: msg.finalAudio,
           durationMs: msg.durationMs,
         });
+      } else {
+        // Resolve the wait even if no audio came back, so stop doesn't hang.
+        session.setAudio(null);
       }
       await closeOffscreen();
       return { ok: true };
     }
     default:
       throw new Error(`unknown message type: ${(msg as { type: string }).type}`);
+  }
+}
+
+/**
+ * Submit a bundle. Default path: POST to the configured endpoint. If no
+ * endpoint is configured, fall through to a local download. If the POST
+ * fails for any reason (network, 4xx, 5xx), still write a local
+ * download so the user never silently loses a recording.
+ */
+async function autoSubmit(bundle: Bundle, cfg: ExtensionConfig): Promise<SubmitResult> {
+  if (!cfg.postEndpoint) {
+    try {
+      const dl = await submitDownload(bundle);
+      return { kind: "downloaded", filename: dl.filename, bytes: dl.bytes, reason: "no_endpoint" };
+    } catch (err) {
+      return { kind: "failed", errorCode: "download_failed", detail: (err as Error).message };
+    }
+  }
+
+  const post = await submitPost(bundle, cfg);
+  if (post.ok) {
+    const result: SubmitResult = { kind: "posted", status: post.status };
+    if (post.traceId) result.traceId = post.traceId;
+    if (post.learnUrl) result.learnUrl = post.learnUrl;
+    return result;
+  }
+
+  // POST failed — fall back to download so the recording is never lost.
+  try {
+    const dl = await submitDownload(bundle);
+    return {
+      kind: "downloaded",
+      filename: dl.filename,
+      bytes: dl.bytes,
+      reason: "post_failed",
+      postError: `${post.errorCode}: ${post.detail}`,
+    };
+  } catch {
+    return { kind: "failed", errorCode: post.errorCode, detail: post.detail };
   }
 }
 

--- a/browser-extension/src/background/session.ts
+++ b/browser-extension/src/background/session.ts
@@ -1,0 +1,226 @@
+// CaptureSession owns the lifecycle of a single recording: attaches the
+// CDP adapter, accumulates exchanges + audio, computes stats, and hands
+// back a Bundle on demand.
+
+import { startCapture, type CaptureSession as InMemSession } from "../capture/buffer.js";
+import { buildBundle } from "../bundle/build.js";
+import type { Bundle } from "../bundle/schema.js";
+import type { HttpExchange, CaptureStats } from "../shared/types.js";
+import { logger } from "../shared/logger.js";
+import type { CaptureAdapter } from "./cdp/adapter.js";
+import { ChromeDebuggerAdapter } from "./cdp/chrome-debugger.js";
+import { clearCapture, persistCapture, type PersistedCapture } from "./storage.js";
+
+export interface CaptureSessionOptions {
+  tabId: number;
+  tabUrl?: string;
+  recordAudio: boolean;
+  bodyMaxBytes: number;
+  hostFilterMode: "all" | "allowlist";
+  hostAllowlist: string[];
+  extensionVersion: string;
+  browser: string;
+}
+
+export interface CaptureSessionEvents {
+  onStats?: (stats: CaptureStats) => void;
+  onError?: (e: { code: string; detail: string }) => void;
+}
+
+export class CaptureSessionRunner {
+  readonly opts: CaptureSessionOptions;
+  private events: CaptureSessionEvents = {};
+  private adapter: CaptureAdapter;
+  private buffer: InMemSession;
+  private intent = "";
+  private narrative = "";
+  private hostFilterPattern: string | null = null;
+  private audio: { mimeType: string; bytes: ArrayBuffer; durationMs: number } | null = null;
+  private byHost = new Map<string, { count: number; bytes: number }>();
+  private totalBytes = 0;
+  private startedAt: string;
+  private statsTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(opts: CaptureSessionOptions, events: CaptureSessionEvents = {}) {
+    this.opts = opts;
+    this.events = events;
+    this.startedAt = new Date().toISOString();
+    this.buffer = startCapture("");
+    this.adapter = new ChromeDebuggerAdapter({ bodyMaxBytes: opts.bodyMaxBytes });
+    this.adapter.onExchange((e) => this.handleExchange(e));
+    this.adapter.onError((e) => this.events.onError?.(e));
+    this.adapter.onNavigation((url) => logger.info("nav boundary", url));
+  }
+
+  get tabId(): number {
+    return this.opts.tabId;
+  }
+
+  async start(): Promise<void> {
+    await this.adapter.attach(this.opts.tabId);
+    this.statsTimer = setInterval(() => this.events.onStats?.(this.snapshot()), 250);
+  }
+
+  async stop(): Promise<void> {
+    if (this.statsTimer) clearInterval(this.statsTimer);
+    this.statsTimer = null;
+    await this.adapter.detach(this.opts.tabId);
+    await this.persist(true);
+  }
+
+  setEvents(events: CaptureSessionEvents): void {
+    this.events = events;
+  }
+
+  setIntent(intent: string, narrative?: string): void {
+    this.intent = intent;
+    if (narrative !== undefined) this.narrative = narrative;
+    void this.persist();
+  }
+
+  setHostFilter(pattern: string | null): void {
+    this.hostFilterPattern = pattern;
+    void this.persist();
+  }
+
+  setAudio(audio: { mimeType: string; bytes: ArrayBuffer; durationMs: number } | null): void {
+    this.audio = audio;
+    void this.persist();
+  }
+
+  snapshot(): CaptureStats {
+    const byHost: Record<string, { count: number; bytes: number }> = {};
+    for (const [host, v] of this.byHost) byHost[host] = { ...v };
+    return {
+      exchangeCount: this.buffer.exchanges.length,
+      totalBytes: this.totalBytes,
+      byHost,
+      startedAt: this.startedAt,
+      durationMs: Date.now() - new Date(this.startedAt).getTime(),
+    };
+  }
+
+  exchanges(): HttpExchange[] {
+    return this.buffer.exchanges;
+  }
+
+  intentText(): string {
+    return this.intent;
+  }
+
+  narrativeText(): string {
+    return this.narrative;
+  }
+
+  buildBundle(includeAudio: boolean): Bundle {
+    const filterFn = this.compileHostFilter();
+    return buildBundle({
+      intent: this.intent || "(no intent provided)",
+      narrative: this.narrative || undefined,
+      exchanges: this.buffer.exchanges,
+      audio: includeAudio ? this.audio : null,
+      hostFilter: filterFn,
+      extensionVersion: this.opts.extensionVersion,
+      browser: this.opts.browser,
+      tabUrl: this.opts.tabUrl,
+    });
+  }
+
+  private compileHostFilter(): ((host: string) => boolean) | null {
+    if (this.opts.hostFilterMode === "allowlist" && this.opts.hostAllowlist.length > 0) {
+      const allow = new Set(this.opts.hostAllowlist.map((h) => h.toLowerCase()));
+      const userPattern = this.hostFilterPattern?.toLowerCase() ?? null;
+      return (host) => {
+        const h = host.toLowerCase();
+        if (!allow.has(h) && !anyMatchesSuffix(allow, h)) return false;
+        if (userPattern && !h.includes(userPattern)) return false;
+        return true;
+      };
+    }
+    if (this.hostFilterPattern) {
+      const p = this.hostFilterPattern.toLowerCase();
+      return (host) => host.toLowerCase().includes(p);
+    }
+    return null;
+  }
+
+  private handleExchange(e: Omit<HttpExchange, "index">): void {
+    this.buffer.add(e);
+    const bytes = approxBytes(e);
+    this.totalBytes += bytes;
+    try {
+      const host = new URL(e.request.url).host;
+      const cur = this.byHost.get(host) ?? { count: 0, bytes: 0 };
+      cur.count++;
+      cur.bytes += bytes;
+      this.byHost.set(host, cur);
+    } catch {
+      /* navigation rows may have non-URL "url" — ignore */
+    }
+    void this.persist();
+  }
+
+  private async persist(force = false): Promise<void> {
+    const state: PersistedCapture = {
+      sessionId: this.buffer.id,
+      startedAt: this.startedAt,
+      intent: this.intent,
+      narrative: this.narrative,
+      exchanges: this.buffer.exchanges,
+      audio: this.audio
+        ? {
+            mimeType: this.audio.mimeType,
+            base64: arrayBufferToBase64(this.audio.bytes),
+            durationMs: this.audio.durationMs,
+          }
+        : null,
+      hostFilter: this.hostFilterPattern,
+      tabId: this.opts.tabId,
+      tabUrl: this.opts.tabUrl ?? null,
+    };
+    await persistCapture(state, force);
+  }
+
+  async discard(): Promise<void> {
+    await clearCapture();
+  }
+}
+
+function approxBytes(e: Omit<HttpExchange, "index">): number {
+  let n = 0;
+  n += JSON.stringify(e.request.headers).length;
+  n += JSON.stringify(e.response.headers).length;
+  n += sizeOfBody(e.request.body);
+  n += sizeOfBody(e.response.body);
+  return n;
+}
+
+function sizeOfBody(b: unknown): number {
+  if (b == null) return 0;
+  if (typeof b === "string") return b.length;
+  try {
+    return JSON.stringify(b).length;
+  } catch {
+    return 0;
+  }
+}
+
+function anyMatchesSuffix(set: Set<string>, host: string): boolean {
+  for (const entry of set) {
+    if (entry.startsWith("*.")) {
+      const suf = entry.slice(1);
+      if (host.endsWith(suf)) return true;
+    }
+  }
+  return false;
+}
+
+function arrayBufferToBase64(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}

--- a/browser-extension/src/background/session.ts
+++ b/browser-extension/src/background/session.ts
@@ -36,6 +36,8 @@ export class CaptureSessionRunner {
   private narrative = "";
   private hostFilterPattern: string | null = null;
   private audio: { mimeType: string; bytes: ArrayBuffer; durationMs: number } | null = null;
+  private audioPromise: Promise<void> | null = null;
+  private audioResolver: (() => void) | null = null;
   private byHost = new Map<string, { count: number; bytes: number }>();
   private totalBytes = 0;
   private startedAt: string;
@@ -85,7 +87,29 @@ export class CaptureSessionRunner {
 
   setAudio(audio: { mimeType: string; bytes: ArrayBuffer; durationMs: number } | null): void {
     this.audio = audio;
+    this.audioResolver?.();
+    this.audioResolver = null;
     void this.persist();
+  }
+
+  /**
+   * Returns a promise that resolves once `setAudio` is called, or after
+   * `timeoutMs` elapses (so a misbehaving offscreen doc can't wedge the
+   * stop flow forever). Idempotent — calling again before resolution
+   * returns the same promise.
+   */
+  awaitAudio(timeoutMs: number): Promise<void> {
+    if (this.audioPromise) return this.audioPromise;
+    this.audioPromise = new Promise<void>((resolve) => {
+      this.audioResolver = resolve;
+      setTimeout(() => {
+        if (this.audioResolver) {
+          this.audioResolver();
+          this.audioResolver = null;
+        }
+      }, timeoutMs);
+    });
+    return this.audioPromise;
   }
 
   snapshot(): CaptureStats {

--- a/browser-extension/src/background/storage.ts
+++ b/browser-extension/src/background/storage.ts
@@ -1,0 +1,38 @@
+// chrome.storage.session is a session-scoped, in-memory key/value store
+// (not persisted to disk). We checkpoint capture state here so that if
+// the service worker gets evicted mid-capture, we can rehydrate on wake.
+
+import type { HttpExchange } from "../shared/types.js";
+
+const CAPTURE_KEY = "specialist.capture";
+const CHECKPOINT_EVERY = 5;
+
+export interface PersistedCapture {
+  sessionId: string;
+  startedAt: string;
+  intent: string;
+  narrative: string;
+  exchanges: HttpExchange[];
+  audio: { mimeType: string; base64: string; durationMs: number } | null;
+  hostFilter: string | null;
+  tabId: number | null;
+  tabUrl: string | null;
+}
+
+let pendingWrites = 0;
+
+export async function persistCapture(state: PersistedCapture, force = false): Promise<void> {
+  pendingWrites++;
+  if (!force && pendingWrites % CHECKPOINT_EVERY !== 0) return;
+  await chrome.storage.session.set({ [CAPTURE_KEY]: state });
+}
+
+export async function loadCapture(): Promise<PersistedCapture | null> {
+  const raw = await chrome.storage.session.get(CAPTURE_KEY);
+  return (raw[CAPTURE_KEY] as PersistedCapture | undefined) ?? null;
+}
+
+export async function clearCapture(): Promise<void> {
+  pendingWrites = 0;
+  await chrome.storage.session.remove(CAPTURE_KEY);
+}

--- a/browser-extension/src/bundle/build.ts
+++ b/browser-extension/src/bundle/build.ts
@@ -1,0 +1,91 @@
+// Assemble a Bundle from a finished capture session.
+
+import { emitHar } from "../capture/har-emit.js";
+import type { HttpExchange } from "../shared/types.js";
+import { BundleSchema, type Bundle } from "./schema.js";
+
+export interface BuildBundleInput {
+  intent: string;
+  narrative?: string;
+  exchanges: HttpExchange[];
+  audio: { mimeType: string; bytes: ArrayBuffer; durationMs: number } | null;
+  hostFilter?: ((host: string) => boolean) | null;
+  extensionVersion: string;
+  browser: string;
+  tabUrl?: string;
+}
+
+export function buildBundle(input: BuildBundleInput): Bundle {
+  const filtered = input.hostFilter
+    ? input.exchanges.filter((e) => keepExchange(e, input.hostFilter!))
+    : input.exchanges;
+
+  const har = emitHar(filtered, {
+    creator: { name: "specialist-extension", version: input.extensionVersion },
+  });
+
+  const bundle: Bundle = {
+    schemaVersion: "1",
+    intent: input.intent,
+    ...(input.narrative ? { narrative: input.narrative } : {}),
+    har,
+    audio: input.audio
+      ? {
+          mimeType: input.audio.mimeType,
+          base64: arrayBufferToBase64(input.audio.bytes),
+          durationMs: input.audio.durationMs,
+        }
+      : null,
+    metadata: {
+      capturedBy: "specialist-extension",
+      extensionVersion: input.extensionVersion,
+      browser: input.browser,
+      capturedAt: new Date().toISOString(),
+      ...(input.tabUrl ? { tabUrl: input.tabUrl } : {}),
+    },
+  };
+
+  return BundleSchema.parse(bundle);
+}
+
+function keepExchange(e: HttpExchange, predicate: (host: string) => boolean): boolean {
+  try {
+    return predicate(new URL(e.request.url).host);
+  } catch {
+    return false;
+  }
+}
+
+export function bundleFilename(date = new Date()): string {
+  const iso = date
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "Z");
+  const id = shortId();
+  return `specialist-bundle-${iso}-${id}.json`;
+}
+
+function shortId(): string {
+  const uuid = crypto.randomUUID().replace(/-/g, "");
+  return base32(uuid).slice(0, 6);
+}
+
+function base32(hex: string): string {
+  const alphabet = "abcdefghijklmnopqrstuvwxyz234567";
+  let out = "";
+  for (let i = 0; i < hex.length; i += 2) {
+    const byte = parseInt(hex.slice(i, i + 2), 16);
+    out += alphabet[byte % 32];
+  }
+  return out;
+}
+
+function arrayBufferToBase64(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}

--- a/browser-extension/src/bundle/schema.ts
+++ b/browser-extension/src/bundle/schema.ts
@@ -1,0 +1,82 @@
+// Source-of-truth zod schema for the on-disk bundle. Mirrored verbatim
+// at `src/bundle/schema.ts` in the host package. The shared fixture
+// `test/fixtures/bundle-example.json` is parsed by both copies so any
+// drift fails CI.
+
+import { z } from "zod";
+
+const HarHeaderSchema = z.object({
+  name: z.string(),
+  value: z.string(),
+});
+
+const HarPostDataSchema = z.object({
+  mimeType: z.string(),
+  text: z.string(),
+});
+
+const HarContentSchema = z.object({
+  mimeType: z.string(),
+  text: z.string(),
+  size: z.number().optional(),
+});
+
+const HarEntrySchema = z.object({
+  startedDateTime: z.string(),
+  time: z.number(),
+  request: z.object({
+    method: z.string(),
+    url: z.string(),
+    httpVersion: z.string().optional(),
+    headers: z.array(HarHeaderSchema),
+    queryString: z.array(HarHeaderSchema).optional(),
+    cookies: z.array(HarHeaderSchema).optional(),
+    headersSize: z.number().optional(),
+    bodySize: z.number().optional(),
+    postData: HarPostDataSchema.optional(),
+  }),
+  response: z.object({
+    status: z.number(),
+    statusText: z.string().optional(),
+    httpVersion: z.string().optional(),
+    headers: z.array(HarHeaderSchema),
+    cookies: z.array(HarHeaderSchema).optional(),
+    headersSize: z.number().optional(),
+    bodySize: z.number().optional(),
+    redirectURL: z.string().optional(),
+    content: HarContentSchema,
+  }),
+  cache: z.record(z.unknown()).optional(),
+  timings: z.record(z.number()).optional(),
+});
+
+export const BundleSchema = z.object({
+  schemaVersion: z.literal("1"),
+  intent: z.string().min(1).max(2000),
+  narrative: z.string().max(50_000).optional(),
+  har: z.object({
+    log: z.object({
+      version: z.literal("1.2"),
+      creator: z.object({ name: z.string(), version: z.string() }),
+      browser: z.object({ name: z.string(), version: z.string() }).optional(),
+      pages: z.array(z.unknown()).optional(),
+      entries: z.array(HarEntrySchema),
+    }),
+  }),
+  audio: z
+    .object({
+      mimeType: z.string(),
+      base64: z.string(),
+      durationMs: z.number(),
+    })
+    .nullable(),
+  metadata: z.object({
+    capturedBy: z.literal("specialist-extension"),
+    extensionVersion: z.string(),
+    browser: z.string(),
+    capturedAt: z.string(),
+    tabUrl: z.string().optional(),
+  }),
+});
+
+export type Bundle = z.infer<typeof BundleSchema>;

--- a/browser-extension/src/bundle/submit-download.ts
+++ b/browser-extension/src/bundle/submit-download.ts
@@ -1,0 +1,29 @@
+// Save the bundle to disk via chrome.downloads. The user is prompted for
+// a save location (saveAs: true) so the file lands somewhere they can
+// pipe into `specialist-agent learn --bundle=...`.
+
+import type { Bundle } from "./schema.js";
+import { bundleFilename } from "./build.js";
+
+export interface DownloadResult {
+  filename: string;
+  bytes: number;
+  downloadId: number;
+}
+
+export async function submitDownload(bundle: Bundle): Promise<DownloadResult> {
+  const json = JSON.stringify(bundle);
+  const filename = bundleFilename();
+  const blob = new Blob([json], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  try {
+    const downloadId = await chrome.downloads.download({
+      url,
+      filename,
+      saveAs: true,
+    });
+    return { filename, bytes: blob.size, downloadId };
+  } finally {
+    setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  }
+}

--- a/browser-extension/src/bundle/submit-post.ts
+++ b/browser-extension/src/bundle/submit-post.ts
@@ -1,0 +1,71 @@
+// POST a bundle to the configured synthesis host. The endpoint contract
+// is documented in `prompts/PLANS/browser-extension.md` §7.2.
+
+import type { ExtensionConfig } from "../shared/config.js";
+import type { Bundle } from "./schema.js";
+
+export interface PostSuccess {
+  ok: true;
+  status: number;
+  traceId?: string;
+  learnUrl?: string;
+}
+
+export interface PostFailure {
+  ok: false;
+  status: number;
+  errorCode: string;
+  detail: string;
+}
+
+export type PostResult = PostSuccess | PostFailure;
+
+export async function submitPost(bundle: Bundle, cfg: ExtensionConfig): Promise<PostResult> {
+  if (!cfg.postEndpoint) {
+    return {
+      ok: false,
+      status: 0,
+      errorCode: "no_endpoint",
+      detail: "POST endpoint is not configured. Set one in the options page.",
+    };
+  }
+
+  const url = `${cfg.postEndpoint.replace(/\/$/, "")}/v1/bundles`;
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (cfg.postBearerToken) headers["Authorization"] = `Bearer ${cfg.postBearerToken}`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, { method: "POST", headers, body: JSON.stringify(bundle) });
+  } catch (err) {
+    return {
+      ok: false,
+      status: 0,
+      errorCode: "network",
+      detail: (err as Error).message,
+    };
+  }
+
+  let parsed: { error?: string; detail?: string; traceId?: string; learnUrl?: string } = {};
+  try {
+    parsed = await res.json();
+  } catch {
+    /* swallow — non-JSON responses surface via status */
+  }
+
+  if (res.ok) {
+    return {
+      ok: true,
+      status: res.status,
+      ...(parsed.traceId ? { traceId: parsed.traceId } : {}),
+      ...(parsed.learnUrl ? { learnUrl: parsed.learnUrl } : {}),
+    };
+  }
+
+  return {
+    ok: false,
+    status: res.status,
+    errorCode: parsed.error ?? `http_${res.status}`,
+    detail: parsed.detail ?? res.statusText,
+  };
+}

--- a/browser-extension/src/capture/buffer.ts
+++ b/browser-extension/src/capture/buffer.ts
@@ -1,0 +1,49 @@
+// Browser port of `src/capture/buffer.ts`. Identical semantics; uses the
+// platform `crypto.randomUUID()` instead of `node:crypto`.
+
+import type { HttpExchange, HttpTrace } from "../shared/types.js";
+import { scrubBody, scrubHeaders } from "./scrub.js";
+
+export interface CaptureSession {
+  id: string;
+  startedAt: string;
+  intent: string;
+  exchanges: HttpExchange[];
+  add(exchange: Omit<HttpExchange, "index">): void;
+  finish(): HttpTrace;
+}
+
+export function startCapture(intent: string): CaptureSession {
+  const exchanges: HttpExchange[] = [];
+  return {
+    id: crypto.randomUUID(),
+    startedAt: new Date().toISOString(),
+    intent,
+    exchanges,
+    add(exchange) {
+      const scrubbed: HttpExchange = {
+        index: exchanges.length,
+        request: {
+          ...exchange.request,
+          headers: scrubHeaders(exchange.request.headers),
+          body: scrubBody(exchange.request.body),
+        },
+        response: {
+          ...exchange.response,
+          headers: scrubHeaders(exchange.response.headers),
+          body: scrubBody(exchange.response.body),
+        },
+      };
+      exchanges.push(scrubbed);
+    },
+    finish(): HttpTrace {
+      return {
+        id: this.id,
+        startedAt: this.startedAt,
+        endedAt: new Date().toISOString(),
+        intent: this.intent,
+        requests: [...exchanges],
+      };
+    },
+  };
+}

--- a/browser-extension/src/capture/har-emit.ts
+++ b/browser-extension/src/capture/har-emit.ts
@@ -1,0 +1,133 @@
+// Convert an HttpExchange[] into HAR 1.2. The shape emitted here is a
+// strict subset of what the host's `importHar` reads (see
+// `src/capture/har.ts`). Bodies are always serialized as strings inside
+// `content.text` / `postData.text`; binary payloads are emitted as a
+// JSON-stringified marker so the existing parser keeps working.
+
+import type { HttpExchange } from "../shared/types.js";
+
+export interface HarFile {
+  log: {
+    version: "1.2";
+    creator: { name: string; version: string };
+    browser?: { name: string; version: string };
+    entries: HarEntry[];
+  };
+}
+
+export interface HarEntry {
+  startedDateTime: string;
+  time: number;
+  request: {
+    method: string;
+    url: string;
+    httpVersion: string;
+    headers: HarHeader[];
+    queryString: HarHeader[];
+    cookies: HarHeader[];
+    headersSize: number;
+    bodySize: number;
+    postData?: { mimeType: string; text: string };
+  };
+  response: {
+    status: number;
+    statusText: string;
+    httpVersion: string;
+    headers: HarHeader[];
+    cookies: HarHeader[];
+    headersSize: number;
+    bodySize: number;
+    redirectURL: string;
+    content: { mimeType: string; text: string; size: number };
+  };
+  cache: Record<string, never>;
+  timings: { send: number; wait: number; receive: number };
+}
+
+interface HarHeader {
+  name: string;
+  value: string;
+}
+
+export interface HarEmitOptions {
+  creator?: { name: string; version: string };
+  browser?: { name: string; version: string };
+}
+
+const DEFAULT_CREATOR = { name: "specialist-extension", version: "0.1.0" };
+
+export function emitHar(exchanges: HttpExchange[], opts: HarEmitOptions = {}): HarFile {
+  return {
+    log: {
+      version: "1.2",
+      creator: opts.creator ?? DEFAULT_CREATOR,
+      ...(opts.browser ? { browser: opts.browser } : {}),
+      entries: exchanges.map(exchangeToEntry),
+    },
+  };
+}
+
+function exchangeToEntry(e: HttpExchange): HarEntry {
+  const reqMime = headerValue(e.request.headers, "content-type") ?? "";
+  const respMime = headerValue(e.response.headers, "content-type") ?? "application/octet-stream";
+
+  return {
+    startedDateTime: e.request.timestamp,
+    time: Math.max(0, e.response.durationMs),
+    request: {
+      method: e.request.method.toUpperCase(),
+      url: e.request.url,
+      httpVersion: "HTTP/1.1",
+      headers: objectToHarHeaders(e.request.headers),
+      queryString: extractQueryString(e.request.url),
+      cookies: [],
+      headersSize: -1,
+      bodySize: e.request.body == null ? 0 : -1,
+      ...(e.request.body == null ? {} : { postData: { mimeType: reqMime, text: bodyToText(e.request.body) } }),
+    },
+    response: {
+      status: e.response.status,
+      statusText: "",
+      httpVersion: "HTTP/1.1",
+      headers: objectToHarHeaders(e.response.headers),
+      cookies: [],
+      headersSize: -1,
+      bodySize: -1,
+      redirectURL: "",
+      content: {
+        mimeType: respMime,
+        text: bodyToText(e.response.body),
+        size: -1,
+      },
+    },
+    cache: {},
+    timings: { send: 0, wait: e.response.durationMs, receive: 0 },
+  };
+}
+
+function objectToHarHeaders(h: Record<string, string>): HarHeader[] {
+  return Object.entries(h).map(([name, value]) => ({ name, value }));
+}
+
+function headerValue(h: Record<string, string>, name: string): string | undefined {
+  const lower = name.toLowerCase();
+  for (const [k, v] of Object.entries(h)) {
+    if (k.toLowerCase() === lower) return v;
+  }
+  return undefined;
+}
+
+function extractQueryString(url: string): HarHeader[] {
+  try {
+    const u = new URL(url);
+    return [...u.searchParams.entries()].map(([name, value]) => ({ name, value }));
+  } catch {
+    return [];
+  }
+}
+
+function bodyToText(body: unknown): string {
+  if (body == null) return "";
+  if (typeof body === "string") return body;
+  return JSON.stringify(body);
+}

--- a/browser-extension/src/capture/scrub.ts
+++ b/browser-extension/src/capture/scrub.ts
@@ -1,0 +1,59 @@
+// Scrub auth headers and tokens out of captures before they hit storage.
+// We replace recognized auth values with {{auth}} placeholders so the
+// trace remains structurally faithful but no secrets are persisted.
+//
+// PORT NOTE: kept byte-for-byte identical to `src/capture/scrub.ts` in the
+// host package. The shared fixture `test/fixtures/scrub-cases.json` runs
+// against both copies in CI; any drift fails the build.
+
+const AUTH_HEADER_NAMES = new Set([
+  "authorization",
+  "x-api-key",
+  "api-key",
+  "x-auth-token",
+  "x-access-token",
+  "cookie",
+  "set-cookie",
+  "proxy-authorization",
+]);
+
+export function scrubHeaders(headers: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    out[k] = AUTH_HEADER_NAMES.has(k.toLowerCase()) ? "{{auth}}" : v;
+  }
+  return out;
+}
+
+export function scrubBody(body: unknown): unknown {
+  if (body == null) return body;
+  if (typeof body === "string") {
+    return body.replace(/(Bearer\s+)[A-Za-z0-9._\-]+/gi, "$1{{auth}}");
+  }
+  if (Array.isArray(body)) return body.map(scrubBody);
+  if (typeof body === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(body as Record<string, unknown>)) {
+      if (looksLikeSecretKey(k)) {
+        out[k] = "{{auth}}";
+      } else {
+        out[k] = scrubBody(v);
+      }
+    }
+    return out;
+  }
+  return body;
+}
+
+function looksLikeSecretKey(key: string): boolean {
+  const k = key.toLowerCase();
+  return (
+    k.includes("api_key") ||
+    k.includes("apikey") ||
+    k.includes("access_token") ||
+    k.includes("refresh_token") ||
+    k.includes("client_secret") ||
+    k === "password" ||
+    k === "secret"
+  );
+}

--- a/browser-extension/src/content/banner.ts
+++ b/browser-extension/src/content/banner.ts
@@ -1,0 +1,60 @@
+// Content script. Renders a friendly overlay over Chrome's yellow
+// "this extension is debugging" banner, plus a Stop button. The script
+// performs no capture — CDP does it all from the SW.
+
+const BANNER_ID = "__specialist_capture_banner__";
+
+(function inject() {
+  if (document.getElementById(BANNER_ID)) return;
+  const root = document.createElement("div");
+  root.id = BANNER_ID;
+  root.setAttribute(
+    "style",
+    [
+      "position:fixed",
+      "top:0",
+      "left:0",
+      "right:0",
+      "z-index:2147483647",
+      "padding:6px 12px",
+      "background:#1f2937",
+      "color:#fff",
+      "font:13px/1.4 -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif",
+      "display:flex",
+      "justify-content:space-between",
+      "align-items:center",
+      "box-shadow:0 1px 4px rgba(0,0,0,.3)",
+    ].join(";"),
+  );
+
+  const label = document.createElement("span");
+  label.textContent = "Specialist Capture is recording this tab.";
+  root.appendChild(label);
+
+  const btn = document.createElement("button");
+  btn.textContent = "Stop";
+  btn.setAttribute(
+    "style",
+    [
+      "background:#ef4444",
+      "border:0",
+      "color:#fff",
+      "padding:4px 10px",
+      "border-radius:4px",
+      "cursor:pointer",
+    ].join(";"),
+  );
+  btn.addEventListener("click", () => {
+    void chrome.runtime.sendMessage({ type: "POPUP_TO_BG_STOP_RECORDING" });
+    root.remove();
+  });
+  root.appendChild(btn);
+
+  document.documentElement.appendChild(root);
+
+  chrome.runtime.onMessage.addListener((msg: { type?: string; state?: string }) => {
+    if (msg?.type === "BG_TO_CONTENT_SHOW_BANNER" && msg.state === "stopped") {
+      root.remove();
+    }
+  });
+})();

--- a/browser-extension/src/offscreen/recorder.html
+++ b/browser-extension/src/offscreen/recorder.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Specialist offscreen recorder</title>
+  </head>
+  <body>
+    <p>Specialist Capture is recording audio.</p>
+    <script type="module" src="./recorder.ts"></script>
+  </body>
+</html>

--- a/browser-extension/src/offscreen/recorder.ts
+++ b/browser-extension/src/offscreen/recorder.ts
@@ -1,0 +1,99 @@
+// Hosts MediaRecorder + the chosen transcriber. The service worker
+// drives lifecycle via BG_TO_OFFSCREEN_* messages; this file replies
+// with OFFSCREEN_TO_BG_* messages.
+
+import type { ClientMessage, ServerMessage } from "../shared/messages.js";
+import { startWebSpeech, type WebSpeechHandle } from "./transcribe-webspeech.js";
+
+interface RuntimeState {
+  recorder: MediaRecorder | null;
+  stream: MediaStream | null;
+  chunks: BlobPart[];
+  startedAt: number;
+  speech: WebSpeechHandle | null;
+  mimeType: string;
+}
+
+const state: RuntimeState = {
+  recorder: null,
+  stream: null,
+  chunks: [],
+  startedAt: 0,
+  speech: null,
+  mimeType: "audio/webm;codecs=opus",
+};
+
+chrome.runtime.onMessage.addListener((msg: ServerMessage, _sender, sendResponse) => {
+  void handle(msg).then(sendResponse).catch((err) => sendResponse({ ok: false, error: (err as Error).message }));
+  return true;
+});
+
+async function handle(msg: ServerMessage): Promise<unknown> {
+  switch (msg.type) {
+    case "BG_TO_OFFSCREEN_START_RECORDING":
+      return start(msg.mimeType, msg.transcriber);
+    case "BG_TO_OFFSCREEN_STOP_RECORDING":
+      return stop();
+    default:
+      return { ok: false, error: `unhandled in offscreen: ${msg.type}` };
+  }
+}
+
+async function start(mimeType: string, transcriber: "webspeech" | "whisper-wasm"): Promise<unknown> {
+  if (state.recorder) return { ok: false, error: "already recording" };
+  let stream: MediaStream;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  } catch (err) {
+    return { ok: false, error: `media_permission: ${(err as Error).message}` };
+  }
+  const recorder = new MediaRecorder(stream, {
+    mimeType,
+    audioBitsPerSecond: 32_000,
+  });
+  state.recorder = recorder;
+  state.stream = stream;
+  state.chunks = [];
+  state.startedAt = Date.now();
+  state.mimeType = mimeType;
+
+  recorder.ondataavailable = (ev: BlobEvent) => {
+    if (ev.data && ev.data.size > 0) state.chunks.push(ev.data);
+  };
+  recorder.start(1000);
+
+  if (transcriber === "webspeech") {
+    state.speech = startWebSpeech((text, isFinal) => {
+      const out: ClientMessage = { type: "OFFSCREEN_TO_BG_TRANSCRIPT_PARTIAL", text, isFinal };
+      void chrome.runtime.sendMessage(out);
+    });
+  }
+  return { ok: true };
+}
+
+async function stop(): Promise<unknown> {
+  const recorder = state.recorder;
+  if (!recorder) return { ok: false, error: "not recording" };
+  state.speech?.stop();
+  state.speech = null;
+
+  const finalAudio = await new Promise<Blob>((resolve) => {
+    recorder.onstop = () => resolve(new Blob(state.chunks, { type: state.mimeType }));
+    recorder.stop();
+  });
+  state.stream?.getTracks().forEach((t) => t.stop());
+
+  const buffer = await finalAudio.arrayBuffer();
+  const out: ClientMessage = {
+    type: "OFFSCREEN_TO_BG_RECORDING_STOPPED",
+    finalAudio: buffer,
+    mimeType: state.mimeType,
+    durationMs: Date.now() - state.startedAt,
+  };
+  await chrome.runtime.sendMessage(out);
+
+  state.recorder = null;
+  state.stream = null;
+  state.chunks = [];
+  return { ok: true };
+}

--- a/browser-extension/src/offscreen/transcribe-webspeech.ts
+++ b/browser-extension/src/offscreen/transcribe-webspeech.ts
@@ -1,0 +1,69 @@
+// Web Speech API wrapper. Chrome-only; sends audio to Google for
+// transcription. Surfaced in the popup with a privacy note.
+
+type AnyWindow = typeof window & {
+  webkitSpeechRecognition?: new () => SpeechRecognition;
+  SpeechRecognition?: new () => SpeechRecognition;
+};
+
+interface SpeechRecognition extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  onresult: ((ev: SpeechRecognitionEvent) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+  onend: (() => void) | null;
+}
+
+interface SpeechRecognitionEvent extends Event {
+  resultIndex: number;
+  results: ArrayLike<SpeechRecognitionResult>;
+}
+
+interface SpeechRecognitionResult {
+  isFinal: boolean;
+  0: { transcript: string; confidence: number };
+}
+
+export interface WebSpeechHandle {
+  stop(): void;
+}
+
+export function startWebSpeech(
+  onPartial: (text: string, isFinal: boolean) => void,
+): WebSpeechHandle | null {
+  const w = self as unknown as AnyWindow;
+  const Ctor = w.SpeechRecognition ?? w.webkitSpeechRecognition;
+  if (!Ctor) return null;
+  const rec = new Ctor();
+  rec.lang = navigator.language || "en-US";
+  rec.continuous = true;
+  rec.interimResults = true;
+  rec.onresult = (ev) => {
+    let interim = "";
+    let final = "";
+    for (let i = ev.resultIndex; i < ev.results.length; i++) {
+      const r = ev.results[i];
+      const t = r[0].transcript;
+      if (r.isFinal) final += t;
+      else interim += t;
+    }
+    if (final) onPartial(final.trim(), true);
+    else if (interim) onPartial(interim.trim(), false);
+  };
+  rec.onerror = () => {
+    /* swallow — we still have the audio blob */
+  };
+  rec.start();
+  return {
+    stop() {
+      try {
+        rec.stop();
+      } catch {
+        /* already stopped */
+      }
+    },
+  };
+}

--- a/browser-extension/src/offscreen/transcribe-webspeech.ts
+++ b/browser-extension/src/offscreen/transcribe-webspeech.ts
@@ -46,6 +46,7 @@ export function startWebSpeech(
     let final = "";
     for (let i = ev.resultIndex; i < ev.results.length; i++) {
       const r = ev.results[i];
+      if (!r) continue;
       const t = r[0].transcript;
       if (r.isFinal) final += t;
       else interim += t;

--- a/browser-extension/src/offscreen/transcribe-whisper.ts
+++ b/browser-extension/src/offscreen/transcribe-whisper.ts
@@ -1,0 +1,18 @@
+// Whisper-tiny (~30MB WASM) fallback for Firefox or "transcribe locally"
+// opt-in on Chrome. The WASM binary is lazy-loaded from /vendor on first
+// use so the base extension stays small.
+//
+// v1: stub interface only — wiring the actual WASM module is gated on
+// shipping the vendor file, which is tracked separately (see plan §4.1
+// + .gitignore).
+
+export interface WhisperHandle {
+  pushPcm(samples: Float32Array): void;
+  finalize(): Promise<string>;
+}
+
+export async function startWhisper(): Promise<WhisperHandle> {
+  // Intentional: the vendor file is added by an out-of-band tool. If it
+  // ever lands, this loader is the single touchpoint.
+  throw new Error("whisper-wasm transcriber is not bundled in this build");
+}

--- a/browser-extension/src/options/Form.tsx
+++ b/browser-extension/src/options/Form.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useState } from "react";
+import { DEFAULT_CONFIG, loadConfig, saveConfig, type ExtensionConfig } from "../shared/config.js";
+
+export function Form() {
+  const [cfg, setCfg] = useState<ExtensionConfig>(DEFAULT_CONFIG);
+  const [saved, setSaved] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    void loadConfig().then((c) => {
+      setCfg(c);
+      setLoading(false);
+    });
+  }, []);
+
+  if (loading) return <p>Loading…</p>;
+
+  const update = <K extends keyof ExtensionConfig>(k: K, v: ExtensionConfig[K]) => {
+    setCfg({ ...cfg, [k]: v });
+    setSaved(false);
+  };
+
+  const onSave = async () => {
+    await saveConfig(cfg);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  return (
+    <>
+      <h1>Specialist Capture — Options</h1>
+      <p className="help">
+        These settings apply to every recording. Bundles are saved to disk by default. To POST
+        bundles directly to a synthesis host, fill in the endpoint and bearer token below.
+      </p>
+
+      <label>
+        POST endpoint (optional)
+        <input
+          type="text"
+          placeholder="https://specialist.acme.internal"
+          value={cfg.postEndpoint ?? ""}
+          onChange={(e) => update("postEndpoint", e.target.value || null)}
+        />
+        <span className="help">
+          The extension POSTs to <code>{cfg.postEndpoint ?? "<endpoint>"}/v1/bundles</code>.
+        </span>
+      </label>
+
+      <label>
+        Bearer token (optional)
+        <input
+          type="password"
+          value={cfg.postBearerToken ?? ""}
+          onChange={(e) => update("postBearerToken", e.target.value || null)}
+        />
+      </label>
+
+      <label>
+        Body byte cap
+        <input
+          type="number"
+          min={1024}
+          step={1024}
+          value={cfg.bodyMaxBytes}
+          onChange={(e) => update("bodyMaxBytes", Number(e.target.value) || DEFAULT_CONFIG.bodyMaxBytes)}
+        />
+        <span className="help">
+          Response bodies larger than this are truncated. Defaults to 1 MiB.
+        </span>
+      </label>
+
+      <label>
+        <input
+          type="checkbox"
+          checked={cfg.retainAudioByDefault}
+          onChange={(e) => update("retainAudioByDefault", e.target.checked)}
+        />{" "}
+        Include audio blob in bundles by default
+      </label>
+
+      <label>
+        Host filter mode
+        <select
+          value={cfg.hostFilterMode}
+          onChange={(e) => update("hostFilterMode", e.target.value as ExtensionConfig["hostFilterMode"])}
+        >
+          <option value="all">Capture all hosts</option>
+          <option value="allowlist">Allowlist only</option>
+        </select>
+      </label>
+
+      {cfg.hostFilterMode === "allowlist" && (
+        <label>
+          Allowlist (one host per line; <code>*.example.com</code> matches subdomains)
+          <textarea
+            value={cfg.hostAllowlist.join("\n")}
+            onChange={(e) =>
+              update(
+                "hostAllowlist",
+                e.target.value.split("\n").map((s) => s.trim()).filter(Boolean),
+              )
+            }
+          />
+        </label>
+      )}
+
+      <label>
+        Transcription engine
+        <select
+          value={cfg.transcriber}
+          onChange={(e) => update("transcriber", e.target.value as ExtensionConfig["transcriber"])}
+        >
+          <option value="webspeech">Web Speech API (Chrome — sends audio to Google)</option>
+          <option value="whisper-wasm">Whisper.wasm (offline; ~30 MB lazy download)</option>
+        </select>
+      </label>
+
+      <button onClick={onSave}>Save</button>
+      {saved && <span className="saved">saved.</span>}
+    </>
+  );
+}

--- a/browser-extension/src/options/index.html
+++ b/browser-extension/src/options/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Specialist Capture — Options</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        max-width: 640px;
+        margin: 24px auto;
+        padding: 0 16px;
+      }
+      h1 { font-size: 20px; }
+      label { display: block; margin: 12px 0; font-size: 13px; }
+      input[type="text"], input[type="password"], input[type="number"], textarea, select {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 6px 8px;
+        font: inherit;
+        border-radius: 4px;
+        border: 1px solid #aaa;
+        margin-top: 4px;
+      }
+      textarea { min-height: 80px; }
+      button {
+        padding: 8px 14px;
+        font-size: 13px;
+        border-radius: 4px;
+        background: #2d7;
+        color: #fff;
+        border: 1px solid #2d7;
+        cursor: pointer;
+      }
+      .help { color: #777; font-size: 12px; }
+      .saved { color: #2a7; font-size: 12px; margin-left: 8px; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./options.tsx"></script>
+  </body>
+</html>

--- a/browser-extension/src/options/options.tsx
+++ b/browser-extension/src/options/options.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { Form } from "./Form.js";
+
+const root = document.getElementById("root");
+if (root) createRoot(root).render(<Form />);

--- a/browser-extension/src/popup/App.tsx
+++ b/browser-extension/src/popup/App.tsx
@@ -6,20 +6,30 @@ import { StatsPanel } from "./components/StatsPanel.js";
 import { HostFilter } from "./components/HostFilter.js";
 import { TranscriptEditor } from "./components/TranscriptEditor.js";
 import { SubmitMenu } from "./components/SubmitMenu.js";
+import { loadConfig } from "../shared/config.js";
 
 export function App() {
-  const { snapshot, start, stop, updateIntent, filterHost, submitDownload, submitPost, discard } = useSession();
-  const { stats, intent: liveIntent, narrative: liveNarrative, error } = useStatsPort();
+  const { snapshot, start, stop, updateIntent, filterHost, downloadFallback, retrySubmit, discard } = useSession();
+  const { stats, intent: liveIntent, narrative: liveNarrative, error, submit } = useStatsPort();
   const [activeTabId, setActiveTabId] = useState<number | null>(null);
+  const [hasEndpoint, setHasEndpoint] = useState(false);
 
   useEffect(() => {
     void chrome.tabs.query({ active: true, currentWindow: true }).then((tabs) => {
       if (tabs[0]?.id != null) setActiveTabId(tabs[0].id);
     });
+    void loadConfig().then((cfg) => setHasEndpoint(!!cfg.postEndpoint));
   }, []);
 
   const intent = liveIntent || snapshot.intent;
   const narrative = liveNarrative || snapshot.narrative;
+
+  const submitState =
+    submit.phase !== "idle"
+      ? submit
+      : snapshot.lastSubmitResult
+      ? ({ phase: "done", result: snapshot.lastSubmitResult } as const)
+      : ({ phase: "idle" } as const);
 
   return (
     <>
@@ -34,9 +44,30 @@ export function App() {
         <>
           <HostFilter onChange={filterHost} />
           <TranscriptEditor intent={intent} narrative={narrative} onChange={updateIntent} />
-          <SubmitMenu onDownload={submitDownload} onPost={submitPost} onDiscard={discard} />
+          {!hasEndpoint && submitState.phase === "idle" && (
+            <div className="stats">
+              No host endpoint configured. The bundle will save locally on Stop.{" "}
+              <a
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  void chrome.runtime.openOptionsPage();
+                }}
+              >
+                Configure endpoint
+              </a>
+            </div>
+          )}
         </>
       )}
+      <SubmitMenu
+        submit={submitState}
+        hasEndpoint={hasEndpoint}
+        onRetry={retrySubmit}
+        onDownloadFallback={downloadFallback}
+        onDiscard={discard}
+        onConfigure={() => void chrome.runtime.openOptionsPage()}
+      />
       {error && (
         <div className="error">
           {error.code}: {error.detail}

--- a/browser-extension/src/popup/App.tsx
+++ b/browser-extension/src/popup/App.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from "react";
+import { useSession } from "./hooks/useSession.js";
+import { useStatsPort } from "./hooks/useStatsPort.js";
+import { StartStop } from "./components/StartStop.js";
+import { StatsPanel } from "./components/StatsPanel.js";
+import { HostFilter } from "./components/HostFilter.js";
+import { TranscriptEditor } from "./components/TranscriptEditor.js";
+import { SubmitMenu } from "./components/SubmitMenu.js";
+
+export function App() {
+  const { snapshot, start, stop, updateIntent, filterHost, submitDownload, submitPost, discard } = useSession();
+  const { stats, intent: liveIntent, narrative: liveNarrative, error } = useStatsPort();
+  const [activeTabId, setActiveTabId] = useState<number | null>(null);
+
+  useEffect(() => {
+    void chrome.tabs.query({ active: true, currentWindow: true }).then((tabs) => {
+      if (tabs[0]?.id != null) setActiveTabId(tabs[0].id);
+    });
+  }, []);
+
+  const intent = liveIntent || snapshot.intent;
+  const narrative = liveNarrative || snapshot.narrative;
+
+  return (
+    <>
+      <h1>Specialist Capture</h1>
+      <StartStop
+        active={snapshot.active}
+        onStart={(rec) => activeTabId != null && start(activeTabId, rec)}
+        onStop={stop}
+      />
+      <StatsPanel stats={stats} />
+      {snapshot.active && (
+        <>
+          <HostFilter onChange={filterHost} />
+          <TranscriptEditor intent={intent} narrative={narrative} onChange={updateIntent} />
+          <SubmitMenu onDownload={submitDownload} onPost={submitPost} onDiscard={discard} />
+        </>
+      )}
+      {error && (
+        <div className="error">
+          {error.code}: {error.detail}
+        </div>
+      )}
+      <div className="privacy">
+        Voice transcription uses Chrome's built-in speech recognition, which may send audio to Google.
+        Toggle Whisper in options to transcribe offline.
+      </div>
+    </>
+  );
+}

--- a/browser-extension/src/popup/components/HostFilter.tsx
+++ b/browser-extension/src/popup/components/HostFilter.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from "react";
+
+interface Props {
+  onChange: (pattern: string | null) => void;
+}
+
+export function HostFilter({ onChange }: Props) {
+  const [value, setValue] = useState("");
+  return (
+    <div className="row">
+      <input
+        type="text"
+        placeholder="filter by host (substring) — blank = include all"
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+          onChange(e.target.value.trim() || null);
+        }}
+      />
+    </div>
+  );
+}

--- a/browser-extension/src/popup/components/StartStop.tsx
+++ b/browser-extension/src/popup/components/StartStop.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from "react";
+
+interface Props {
+  active: boolean;
+  onStart: (recordAudio: boolean) => void;
+  onStop: () => void;
+}
+
+export function StartStop({ active, onStart, onStop }: Props) {
+  const [recordAudio, setRecordAudio] = useState(false);
+  return (
+    <div className="row">
+      {active ? (
+        <button className="danger" onClick={onStop}>
+          Stop
+        </button>
+      ) : (
+        <>
+          <button className="primary" onClick={() => onStart(recordAudio)}>
+            Start
+          </button>
+          <label>
+            <input
+              type="checkbox"
+              checked={recordAudio}
+              onChange={(e) => setRecordAudio(e.target.checked)}
+            />{" "}
+            narrate aloud
+          </label>
+        </>
+      )}
+    </div>
+  );
+}

--- a/browser-extension/src/popup/components/StatsPanel.tsx
+++ b/browser-extension/src/popup/components/StatsPanel.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import type { CaptureStats } from "../../shared/types.js";
+
+interface Props {
+  stats: CaptureStats | null;
+}
+
+export function StatsPanel({ stats }: Props) {
+  if (!stats) {
+    return <div className="stats">No requests captured yet.</div>;
+  }
+  const hosts = Object.entries(stats.byHost).sort((a, b) => b[1].count - a[1].count);
+  const seconds = Math.max(1, Math.round(stats.durationMs / 1000));
+  return (
+    <div className="stats">
+      <div>
+        {stats.exchangeCount} requests · {formatBytes(stats.totalBytes)} · {seconds}s
+      </div>
+      {hosts.length > 0 && (
+        <table>
+          <thead>
+            <tr>
+              <th>Host</th>
+              <th>Count</th>
+              <th>Bytes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {hosts.slice(0, 8).map(([host, v]) => (
+              <tr key={host}>
+                <td>{host}</td>
+                <td>{v.count}</td>
+                <td>{formatBytes(v.bytes)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+}

--- a/browser-extension/src/popup/components/SubmitMenu.tsx
+++ b/browser-extension/src/popup/components/SubmitMenu.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from "react";
+
+interface Props {
+  onDownload: () => Promise<unknown>;
+  onPost: () => Promise<unknown>;
+  onDiscard: () => Promise<void>;
+}
+
+export function SubmitMenu({ onDownload, onPost, onDiscard }: Props) {
+  const [busy, setBusy] = useState<"none" | "download" | "post" | "discard">("none");
+  const [result, setResult] = useState<string | null>(null);
+
+  const guard = async (kind: "download" | "post" | "discard", fn: () => Promise<unknown>) => {
+    setBusy(kind);
+    setResult(null);
+    try {
+      const r = (await fn()) as { ok?: boolean; status?: number; filename?: string; errorCode?: string; detail?: string; traceId?: string };
+      if (r?.ok === false) setResult(`error: ${r.errorCode ?? "unknown"} — ${r.detail ?? ""}`);
+      else if (r?.filename) setResult(`saved ${r.filename}`);
+      else if (r?.traceId) setResult(`accepted (trace ${r.traceId})`);
+      else if (kind === "post" && r?.status && r.status >= 200 && r.status < 300) setResult(`posted (status ${r.status})`);
+      else if (kind === "discard") setResult("discarded");
+      else setResult("done");
+    } catch (e) {
+      setResult(`error: ${(e as Error).message}`);
+    } finally {
+      setBusy("none");
+    }
+  };
+
+  return (
+    <>
+      <div className="row">
+        <button disabled={busy !== "none"} onClick={() => guard("download", onDownload)}>
+          {busy === "download" ? "…" : "Download bundle"}
+        </button>
+        <button disabled={busy !== "none"} onClick={() => guard("post", onPost)}>
+          {busy === "post" ? "…" : "Submit to host"}
+        </button>
+        <button disabled={busy !== "none"} onClick={() => guard("discard", onDiscard)}>
+          Discard
+        </button>
+      </div>
+      {result && <div className="stats">{result}</div>}
+    </>
+  );
+}

--- a/browser-extension/src/popup/components/SubmitMenu.tsx
+++ b/browser-extension/src/popup/components/SubmitMenu.tsx
@@ -1,47 +1,86 @@
-import React, { useState } from "react";
+import React from "react";
+import type { SubmitResult } from "../../shared/messages.js";
+import type { SubmitState } from "../hooks/useStatsPort.js";
 
 interface Props {
-  onDownload: () => Promise<unknown>;
-  onPost: () => Promise<unknown>;
+  submit: SubmitState;
+  hasEndpoint: boolean;
+  onRetry: () => Promise<unknown>;
+  onDownloadFallback: () => Promise<unknown>;
   onDiscard: () => Promise<void>;
+  onConfigure: () => void;
 }
 
-export function SubmitMenu({ onDownload, onPost, onDiscard }: Props) {
-  const [busy, setBusy] = useState<"none" | "download" | "post" | "discard">("none");
-  const [result, setResult] = useState<string | null>(null);
-
-  const guard = async (kind: "download" | "post" | "discard", fn: () => Promise<unknown>) => {
-    setBusy(kind);
-    setResult(null);
-    try {
-      const r = (await fn()) as { ok?: boolean; status?: number; filename?: string; errorCode?: string; detail?: string; traceId?: string };
-      if (r?.ok === false) setResult(`error: ${r.errorCode ?? "unknown"} — ${r.detail ?? ""}`);
-      else if (r?.filename) setResult(`saved ${r.filename}`);
-      else if (r?.traceId) setResult(`accepted (trace ${r.traceId})`);
-      else if (kind === "post" && r?.status && r.status >= 200 && r.status < 300) setResult(`posted (status ${r.status})`);
-      else if (kind === "discard") setResult("discarded");
-      else setResult("done");
-    } catch (e) {
-      setResult(`error: ${(e as Error).message}`);
-    } finally {
-      setBusy("none");
-    }
-  };
-
+/**
+ * Auto-submit status panel. The extension POSTs to the configured
+ * backend automatically on Stop. This panel shows progress + result;
+ * the user only needs to act when something went wrong.
+ */
+export function SubmitMenu({ submit, hasEndpoint, onRetry, onDownloadFallback, onDiscard, onConfigure }: Props) {
+  if (submit.phase === "idle") return null;
+  if (submit.phase === "pending") {
+    return (
+      <div className="stats">
+        {hasEndpoint ? "Submitting to host…" : "Saving bundle…"}
+      </div>
+    );
+  }
   return (
     <>
+      {renderResult(submit.result)}
       <div className="row">
-        <button disabled={busy !== "none"} onClick={() => guard("download", onDownload)}>
-          {busy === "download" ? "…" : "Download bundle"}
-        </button>
-        <button disabled={busy !== "none"} onClick={() => guard("post", onPost)}>
-          {busy === "post" ? "…" : "Submit to host"}
-        </button>
-        <button disabled={busy !== "none"} onClick={() => guard("discard", onDiscard)}>
-          Discard
-        </button>
+        {submit.result.kind === "downloaded" && submit.result.reason !== "no_endpoint" && (
+          <button onClick={() => onRetry()}>Retry submit</button>
+        )}
+        {submit.result.kind === "failed" && (
+          <>
+            <button onClick={() => onRetry()}>Retry submit</button>
+            <button onClick={() => onDownloadFallback()}>Save locally</button>
+          </>
+        )}
+        {submit.result.kind === "downloaded" && submit.result.reason === "no_endpoint" && (
+          <button onClick={onConfigure}>Configure endpoint</button>
+        )}
+        <button onClick={() => onDiscard()}>Done</button>
       </div>
-      {result && <div className="stats">{result}</div>}
     </>
+  );
+}
+
+function renderResult(r: SubmitResult): React.ReactNode {
+  if (r.kind === "posted") {
+    return (
+      <div className="stats">
+        Submitted to host{r.traceId ? ` (trace ${r.traceId})` : ""}
+        {r.learnUrl && (
+          <>
+            {" — "}
+            <a href={r.learnUrl} target="_blank" rel="noreferrer">
+              view
+            </a>
+          </>
+        )}
+        .
+      </div>
+    );
+  }
+  if (r.kind === "downloaded") {
+    if (r.reason === "no_endpoint") {
+      return (
+        <div className="stats">
+          No host endpoint configured — saved <code>{r.filename}</code> locally instead.
+        </div>
+      );
+    }
+    return (
+      <div className="error">
+        Submit to host failed ({r.postError ?? "unknown"}). Saved <code>{r.filename}</code> locally as a fallback.
+      </div>
+    );
+  }
+  return (
+    <div className="error">
+      Submit failed: {r.errorCode} — {r.detail}
+    </div>
   );
 }

--- a/browser-extension/src/popup/components/TranscriptEditor.tsx
+++ b/browser-extension/src/popup/components/TranscriptEditor.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useRef, useState } from "react";
+
+interface Props {
+  intent: string;
+  narrative: string;
+  onChange: (intent: string, narrative: string) => void;
+}
+
+export function TranscriptEditor({ intent, narrative, onChange }: Props) {
+  const [localIntent, setLocalIntent] = useState(intent);
+  const [localNarrative, setLocalNarrative] = useState(narrative);
+  const [expanded, setExpanded] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => setLocalIntent(intent), [intent]);
+  useEffect(() => setLocalNarrative(narrative), [narrative]);
+
+  const schedule = (i: string, n: string) => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => onChange(i, n), 300);
+  };
+
+  return (
+    <>
+      <div className="row">
+        <input
+          type="text"
+          placeholder="intent (one line)"
+          value={localIntent}
+          onChange={(e) => {
+            setLocalIntent(e.target.value);
+            schedule(e.target.value, localNarrative);
+          }}
+        />
+      </div>
+      <div className="row">
+        <button onClick={() => setExpanded((v) => !v)}>
+          {expanded ? "Hide" : "Show"} narration
+        </button>
+      </div>
+      {expanded && (
+        <div className="row">
+          <textarea
+            placeholder="optional voice/narration text"
+            value={localNarrative}
+            onChange={(e) => {
+              setLocalNarrative(e.target.value);
+              schedule(localIntent, e.target.value);
+            }}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/browser-extension/src/popup/hooks/useSession.ts
+++ b/browser-extension/src/popup/hooks/useSession.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState, useCallback } from "react";
+import type { ClientMessage } from "../../shared/messages.js";
+
+export interface SessionSnapshot {
+  active: boolean;
+  intent: string;
+  narrative: string;
+}
+
+export function useSession() {
+  const [snapshot, setSnapshot] = useState<SessionSnapshot>({
+    active: false,
+    intent: "",
+    narrative: "",
+  });
+
+  useEffect(() => {
+    void send({ type: "POPUP_TO_BG_GET_SNAPSHOT" }).then((res: any) => {
+      if (res?.active) {
+        setSnapshot({ active: true, intent: res.intent ?? "", narrative: res.narrative ?? "" });
+      }
+    });
+  }, []);
+
+  const start = useCallback(async (tabId: number, recordAudio: boolean) => {
+    await send({ type: "POPUP_TO_BG_START_RECORDING", tabId, recordAudio });
+    setSnapshot((s) => ({ ...s, active: true }));
+  }, []);
+
+  const stop = useCallback(async () => {
+    await send({ type: "POPUP_TO_BG_STOP_RECORDING" });
+  }, []);
+
+  const updateIntent = useCallback(async (intent: string, narrative: string) => {
+    setSnapshot((s) => ({ ...s, intent, narrative }));
+    await send({ type: "POPUP_TO_BG_UPDATE_INTENT", intent, narrative });
+  }, []);
+
+  const filterHost = useCallback(async (pattern: string | null) => {
+    await send({ type: "POPUP_TO_BG_FILTER_HOST", hostPattern: pattern });
+  }, []);
+
+  const submitDownload = useCallback(async () => {
+    return send({ type: "POPUP_TO_BG_SUBMIT_DOWNLOAD" });
+  }, []);
+
+  const submitPost = useCallback(async () => {
+    return send({ type: "POPUP_TO_BG_SUBMIT_POST" });
+  }, []);
+
+  const discard = useCallback(async () => {
+    await send({ type: "POPUP_TO_BG_DISCARD" });
+    setSnapshot({ active: false, intent: "", narrative: "" });
+  }, []);
+
+  return { snapshot, start, stop, updateIntent, filterHost, submitDownload, submitPost, discard };
+}
+
+function send(msg: ClientMessage): Promise<unknown> {
+  return chrome.runtime.sendMessage(msg);
+}

--- a/browser-extension/src/popup/hooks/useSession.ts
+++ b/browser-extension/src/popup/hooks/useSession.ts
@@ -1,10 +1,11 @@
 import { useEffect, useState, useCallback } from "react";
-import type { ClientMessage } from "../../shared/messages.js";
+import type { ClientMessage, SubmitResult } from "../../shared/messages.js";
 
 export interface SessionSnapshot {
   active: boolean;
   intent: string;
   narrative: string;
+  lastSubmitResult: SubmitResult | null;
 }
 
 export function useSession() {
@@ -12,19 +13,23 @@ export function useSession() {
     active: false,
     intent: "",
     narrative: "",
+    lastSubmitResult: null,
   });
 
   useEffect(() => {
     void send({ type: "POPUP_TO_BG_GET_SNAPSHOT" }).then((res: any) => {
-      if (res?.active) {
-        setSnapshot({ active: true, intent: res.intent ?? "", narrative: res.narrative ?? "" });
-      }
+      setSnapshot({
+        active: !!res?.active,
+        intent: res?.intent ?? "",
+        narrative: res?.narrative ?? "",
+        lastSubmitResult: res?.lastSubmitResult ?? null,
+      });
     });
   }, []);
 
   const start = useCallback(async (tabId: number, recordAudio: boolean) => {
     await send({ type: "POPUP_TO_BG_START_RECORDING", tabId, recordAudio });
-    setSnapshot((s) => ({ ...s, active: true }));
+    setSnapshot((s) => ({ ...s, active: true, lastSubmitResult: null }));
   }, []);
 
   const stop = useCallback(async () => {
@@ -40,20 +45,20 @@ export function useSession() {
     await send({ type: "POPUP_TO_BG_FILTER_HOST", hostPattern: pattern });
   }, []);
 
-  const submitDownload = useCallback(async () => {
-    return send({ type: "POPUP_TO_BG_SUBMIT_DOWNLOAD" });
+  const downloadFallback = useCallback(async () => {
+    return send({ type: "POPUP_TO_BG_DOWNLOAD_FALLBACK" });
   }, []);
 
-  const submitPost = useCallback(async () => {
-    return send({ type: "POPUP_TO_BG_SUBMIT_POST" });
+  const retrySubmit = useCallback(async () => {
+    return send({ type: "POPUP_TO_BG_RETRY_SUBMIT" });
   }, []);
 
   const discard = useCallback(async () => {
     await send({ type: "POPUP_TO_BG_DISCARD" });
-    setSnapshot({ active: false, intent: "", narrative: "" });
+    setSnapshot({ active: false, intent: "", narrative: "", lastSubmitResult: null });
   }, []);
 
-  return { snapshot, start, stop, updateIntent, filterHost, submitDownload, submitPost, discard };
+  return { snapshot, start, stop, updateIntent, filterHost, downloadFallback, retrySubmit, discard };
 }
 
 function send(msg: ClientMessage): Promise<unknown> {

--- a/browser-extension/src/popup/hooks/useStatsPort.ts
+++ b/browser-extension/src/popup/hooks/useStatsPort.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import type { ServerMessage } from "../../shared/messages.js";
+import { POPUP_STATS_PORT } from "../../shared/messages.js";
+import type { CaptureStats, ErrorCode } from "../../shared/types.js";
+
+export interface PortState {
+  stats: CaptureStats | null;
+  intent: string;
+  narrative: string;
+  error: { code: ErrorCode; detail: string } | null;
+}
+
+export function useStatsPort(): PortState {
+  const [state, setState] = useState<PortState>({
+    stats: null,
+    intent: "",
+    narrative: "",
+    error: null,
+  });
+
+  useEffect(() => {
+    const port = chrome.runtime.connect({ name: POPUP_STATS_PORT });
+    const listener = (msg: ServerMessage) => {
+      if (msg.type === "BG_TO_POPUP_CAPTURE_STATS") {
+        setState((s) => ({ ...s, stats: msg.stats }));
+      } else if (msg.type === "BG_TO_POPUP_TRANSCRIPT") {
+        setState((s) => ({ ...s, intent: msg.intent, narrative: msg.narrative }));
+      } else if (msg.type === "BG_TO_POPUP_ERROR") {
+        setState((s) => ({ ...s, error: { code: msg.code, detail: msg.detail } }));
+      }
+    };
+    port.onMessage.addListener(listener);
+    return () => {
+      port.onMessage.removeListener(listener);
+      port.disconnect();
+    };
+  }, []);
+
+  return state;
+}

--- a/browser-extension/src/popup/hooks/useStatsPort.ts
+++ b/browser-extension/src/popup/hooks/useStatsPort.ts
@@ -1,13 +1,19 @@
 import { useEffect, useState } from "react";
-import type { ServerMessage } from "../../shared/messages.js";
+import type { ServerMessage, SubmitResult } from "../../shared/messages.js";
 import { POPUP_STATS_PORT } from "../../shared/messages.js";
 import type { CaptureStats, ErrorCode } from "../../shared/types.js";
+
+export type SubmitState =
+  | { phase: "idle" }
+  | { phase: "pending" }
+  | { phase: "done"; result: SubmitResult };
 
 export interface PortState {
   stats: CaptureStats | null;
   intent: string;
   narrative: string;
   error: { code: ErrorCode; detail: string } | null;
+  submit: SubmitState;
 }
 
 export function useStatsPort(): PortState {
@@ -16,6 +22,7 @@ export function useStatsPort(): PortState {
     intent: "",
     narrative: "",
     error: null,
+    submit: { phase: "idle" },
   });
 
   useEffect(() => {
@@ -27,6 +34,10 @@ export function useStatsPort(): PortState {
         setState((s) => ({ ...s, intent: msg.intent, narrative: msg.narrative }));
       } else if (msg.type === "BG_TO_POPUP_ERROR") {
         setState((s) => ({ ...s, error: { code: msg.code, detail: msg.detail } }));
+      } else if (msg.type === "BG_TO_POPUP_SUBMIT_PENDING") {
+        setState((s) => ({ ...s, submit: { phase: "pending" } }));
+      } else if (msg.type === "BG_TO_POPUP_SUBMIT_RESULT") {
+        setState((s) => ({ ...s, submit: { phase: "done", result: msg.result } }));
       }
     };
     port.onMessage.addListener(listener);

--- a/browser-extension/src/popup/index.html
+++ b/browser-extension/src/popup/index.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Specialist Capture</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-size: 13px;
+      }
+      body {
+        width: 380px;
+        margin: 0;
+        padding: 12px;
+      }
+      h1 {
+        font-size: 14px;
+        margin: 0 0 8px;
+      }
+      .row {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        margin: 6px 0;
+      }
+      button {
+        padding: 6px 10px;
+        font-size: 12px;
+        border-radius: 4px;
+        border: 1px solid #888;
+        background: #f6f6f6;
+        cursor: pointer;
+      }
+      button.primary {
+        background: #2d7;
+        color: #fff;
+        border-color: #2d7;
+      }
+      button.danger {
+        background: #d44;
+        color: #fff;
+        border-color: #d44;
+      }
+      button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+      input[type="text"],
+      textarea {
+        width: 100%;
+        box-sizing: border-box;
+        font: inherit;
+        padding: 4px 6px;
+        border-radius: 4px;
+        border: 1px solid #aaa;
+      }
+      textarea {
+        resize: vertical;
+        min-height: 56px;
+      }
+      .stats {
+        font-size: 12px;
+        color: #555;
+      }
+      .stats table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 4px;
+      }
+      .stats th,
+      .stats td {
+        text-align: left;
+        padding: 2px 4px;
+        border-bottom: 1px solid #eee;
+      }
+      .error {
+        color: #c22;
+        background: #fee;
+        padding: 6px;
+        border-radius: 4px;
+      }
+      .privacy {
+        font-size: 11px;
+        color: #777;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./popup.tsx"></script>
+  </body>
+</html>

--- a/browser-extension/src/popup/popup.tsx
+++ b/browser-extension/src/popup/popup.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.js";
+
+const root = document.getElementById("root");
+if (root) createRoot(root).render(<App />);

--- a/browser-extension/src/shared/config.ts
+++ b/browser-extension/src/shared/config.ts
@@ -1,0 +1,31 @@
+export interface ExtensionConfig {
+  postEndpoint: string | null;
+  postBearerToken: string | null;
+  retainAudioByDefault: boolean;
+  bodyMaxBytes: number;
+  hostFilterMode: "all" | "allowlist";
+  hostAllowlist: string[];
+  transcriber: "webspeech" | "whisper-wasm";
+}
+
+export const DEFAULT_CONFIG: ExtensionConfig = {
+  postEndpoint: null,
+  postBearerToken: null,
+  retainAudioByDefault: false,
+  bodyMaxBytes: 1_048_576,
+  hostFilterMode: "all",
+  hostAllowlist: [],
+  transcriber: "webspeech",
+};
+
+const CONFIG_KEY = "specialist.config";
+
+export async function loadConfig(): Promise<ExtensionConfig> {
+  const raw = await chrome.storage.sync.get(CONFIG_KEY);
+  const stored = raw[CONFIG_KEY] as Partial<ExtensionConfig> | undefined;
+  return { ...DEFAULT_CONFIG, ...(stored ?? {}) };
+}
+
+export async function saveConfig(cfg: ExtensionConfig): Promise<void> {
+  await chrome.storage.sync.set({ [CONFIG_KEY]: cfg });
+}

--- a/browser-extension/src/shared/logger.ts
+++ b/browser-extension/src/shared/logger.ts
@@ -1,0 +1,8 @@
+const PREFIX = "[specialist]";
+
+export const logger = {
+  info: (...args: unknown[]) => console.log(PREFIX, ...args),
+  warn: (...args: unknown[]) => console.warn(PREFIX, ...args),
+  error: (...args: unknown[]) => console.error(PREFIX, ...args),
+  debug: (...args: unknown[]) => console.debug(PREFIX, ...args),
+};

--- a/browser-extension/src/shared/messages.ts
+++ b/browser-extension/src/shared/messages.ts
@@ -1,0 +1,28 @@
+import type { BundleSummary, CaptureStats, ErrorCode } from "./types.js";
+import type { ExtensionConfig } from "./config.js";
+
+export type ClientMessage =
+  | { type: "POPUP_TO_BG_START_RECORDING"; tabId: number; recordAudio: boolean }
+  | { type: "POPUP_TO_BG_STOP_RECORDING" }
+  | { type: "POPUP_TO_BG_GET_SNAPSHOT" }
+  | { type: "POPUP_TO_BG_UPDATE_INTENT"; intent: string; narrative?: string }
+  | { type: "POPUP_TO_BG_FILTER_HOST"; hostPattern: string | null }
+  | { type: "POPUP_TO_BG_BUILD_BUNDLE"; includeAudio: boolean }
+  | { type: "POPUP_TO_BG_SUBMIT_DOWNLOAD" }
+  | { type: "POPUP_TO_BG_SUBMIT_POST" }
+  | { type: "POPUP_TO_BG_DISCARD" }
+  | { type: "OPTIONS_TO_BG_SET_CONFIG"; config: ExtensionConfig }
+  | { type: "OFFSCREEN_TO_BG_AUDIO_CHUNK"; chunk: ArrayBuffer; mimeType: string }
+  | { type: "OFFSCREEN_TO_BG_TRANSCRIPT_PARTIAL"; text: string; isFinal: boolean }
+  | { type: "OFFSCREEN_TO_BG_RECORDING_STOPPED"; finalAudio: ArrayBuffer | null; mimeType: string; durationMs: number };
+
+export type ServerMessage =
+  | { type: "BG_TO_POPUP_CAPTURE_STATS"; stats: CaptureStats }
+  | { type: "BG_TO_POPUP_BUNDLE_READY"; bundle: BundleSummary }
+  | { type: "BG_TO_POPUP_TRANSCRIPT"; intent: string; narrative: string }
+  | { type: "BG_TO_POPUP_ERROR"; code: ErrorCode; detail: string }
+  | { type: "BG_TO_OFFSCREEN_START_RECORDING"; mimeType: string; transcriber: "webspeech" | "whisper-wasm" }
+  | { type: "BG_TO_OFFSCREEN_STOP_RECORDING" }
+  | { type: "BG_TO_CONTENT_SHOW_BANNER"; state: "recording" | "stopped" };
+
+export const POPUP_STATS_PORT = "popup-stats";

--- a/browser-extension/src/shared/messages.ts
+++ b/browser-extension/src/shared/messages.ts
@@ -1,6 +1,11 @@
 import type { BundleSummary, CaptureStats, ErrorCode } from "./types.js";
 import type { ExtensionConfig } from "./config.js";
 
+export type SubmitResult =
+  | { kind: "posted"; status: number; traceId?: string; learnUrl?: string }
+  | { kind: "downloaded"; filename: string; bytes: number; reason: "no_endpoint" | "post_failed"; postError?: string }
+  | { kind: "failed"; errorCode: string; detail: string };
+
 export type ClientMessage =
   | { type: "POPUP_TO_BG_START_RECORDING"; tabId: number; recordAudio: boolean }
   | { type: "POPUP_TO_BG_STOP_RECORDING" }
@@ -8,8 +13,8 @@ export type ClientMessage =
   | { type: "POPUP_TO_BG_UPDATE_INTENT"; intent: string; narrative?: string }
   | { type: "POPUP_TO_BG_FILTER_HOST"; hostPattern: string | null }
   | { type: "POPUP_TO_BG_BUILD_BUNDLE"; includeAudio: boolean }
-  | { type: "POPUP_TO_BG_SUBMIT_DOWNLOAD" }
-  | { type: "POPUP_TO_BG_SUBMIT_POST" }
+  | { type: "POPUP_TO_BG_DOWNLOAD_FALLBACK" }
+  | { type: "POPUP_TO_BG_RETRY_SUBMIT" }
   | { type: "POPUP_TO_BG_DISCARD" }
   | { type: "OPTIONS_TO_BG_SET_CONFIG"; config: ExtensionConfig }
   | { type: "OFFSCREEN_TO_BG_AUDIO_CHUNK"; chunk: ArrayBuffer; mimeType: string }
@@ -19,6 +24,8 @@ export type ClientMessage =
 export type ServerMessage =
   | { type: "BG_TO_POPUP_CAPTURE_STATS"; stats: CaptureStats }
   | { type: "BG_TO_POPUP_BUNDLE_READY"; bundle: BundleSummary }
+  | { type: "BG_TO_POPUP_SUBMIT_RESULT"; result: SubmitResult }
+  | { type: "BG_TO_POPUP_SUBMIT_PENDING" }
   | { type: "BG_TO_POPUP_TRANSCRIPT"; intent: string; narrative: string }
   | { type: "BG_TO_POPUP_ERROR"; code: ErrorCode; detail: string }
   | { type: "BG_TO_OFFSCREEN_START_RECORDING"; mimeType: string; transcriber: "webspeech" | "whisper-wasm" }

--- a/browser-extension/src/shared/types.ts
+++ b/browser-extension/src/shared/types.ts
@@ -1,0 +1,52 @@
+// Mirrors `src/types.ts` from the host package. Kept identical so the
+// extension's HAR emit and the host's HAR import speak the same shape.
+
+export interface HttpTrace {
+  id: string;
+  startedAt: string;
+  endedAt: string;
+  intent: string;
+  requests: HttpExchange[];
+}
+
+export interface HttpExchange {
+  index: number;
+  request: {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    body: unknown;
+    timestamp: string;
+  };
+  response: {
+    status: number;
+    headers: Record<string, string>;
+    body: unknown;
+    durationMs: number;
+  };
+}
+
+export interface CaptureStats {
+  exchangeCount: number;
+  totalBytes: number;
+  byHost: Record<string, { count: number; bytes: number }>;
+  startedAt: string;
+  durationMs: number;
+}
+
+export interface BundleSummary {
+  filename: string;
+  bytes: number;
+  exchangeCount: number;
+  hasAudio: boolean;
+}
+
+export type ErrorCode =
+  | "cdp_attach_failed"
+  | "devtools_open"
+  | "tab_closed"
+  | "offscreen_failed"
+  | "media_permission_denied"
+  | "post_failed"
+  | "bundle_too_large"
+  | "internal";

--- a/browser-extension/test/bundle-build.test.ts
+++ b/browser-extension/test/bundle-build.test.ts
@@ -1,0 +1,72 @@
+// Bundle assembly + schema parse, on the extension side.
+
+import { describe, test, expect } from "vitest";
+import fixture from "../../test/fixtures/bundle-example.json" with { type: "json" };
+import { BundleSchema } from "../src/bundle/schema.js";
+import { buildBundle } from "../src/bundle/build.js";
+import type { HttpExchange } from "../src/shared/types.js";
+
+describe("BundleSchema", () => {
+  test("parses the shared fixture", () => {
+    const parsed = BundleSchema.parse(fixture);
+    expect(parsed.har.log.entries).toHaveLength(1);
+  });
+});
+
+describe("buildBundle", () => {
+  test("produces a schema-valid bundle from a single exchange", () => {
+    const exchanges: HttpExchange[] = [
+      {
+        index: 0,
+        request: {
+          method: "POST",
+          url: "https://api.stripe.com/v1/customers",
+          headers: { Authorization: "{{auth}}", "Content-Type": "application/x-www-form-urlencoded" },
+          body: "email=alice%40acme.com",
+          timestamp: "2026-05-02T15:30:11.123Z",
+        },
+        response: {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+          body: { id: "cus_abc" },
+          durationMs: 142,
+        },
+      },
+    ];
+    const bundle = buildBundle({
+      intent: "create a customer",
+      exchanges,
+      audio: null,
+      extensionVersion: "0.1.0",
+      browser: "chrome/120",
+    });
+    expect(() => BundleSchema.parse(bundle)).not.toThrow();
+    expect(bundle.har.log.entries).toHaveLength(1);
+    expect(bundle.har.log.entries[0]!.request.method).toBe("POST");
+  });
+
+  test("hostFilter trims out non-matching hosts", () => {
+    const exchanges: HttpExchange[] = [
+      mkExchange("https://api.stripe.com/v1/customers"),
+      mkExchange("https://www.google-analytics.com/g/collect"),
+    ];
+    const bundle = buildBundle({
+      intent: "x",
+      exchanges,
+      audio: null,
+      hostFilter: (h) => h.endsWith("stripe.com"),
+      extensionVersion: "0.1.0",
+      browser: "chrome/120",
+    });
+    expect(bundle.har.log.entries).toHaveLength(1);
+    expect(bundle.har.log.entries[0]!.request.url).toContain("stripe.com");
+  });
+});
+
+function mkExchange(url: string): HttpExchange {
+  return {
+    index: 0,
+    request: { method: "GET", url, headers: {}, body: null, timestamp: new Date().toISOString() },
+    response: { status: 200, headers: {}, body: null, durationMs: 1 },
+  };
+}

--- a/browser-extension/test/cdp-reconstruct.test.ts
+++ b/browser-extension/test/cdp-reconstruct.test.ts
@@ -1,0 +1,159 @@
+// Replay a recorded CDP event sequence into the reconstructor and
+// assert the resulting HttpExchange[] matches expectations.
+
+import { describe, test, expect } from "vitest";
+import { CdpReconstructor } from "../src/background/cdp/reconstruct.js";
+import type { HttpExchange } from "../src/shared/types.js";
+
+describe("CdpReconstructor", () => {
+  test("single GET — request → response → loadingFinished", async () => {
+    const exchanges: Omit<HttpExchange, "index">[] = [];
+    const r = new CdpReconstructor({
+      bodyMaxBytes: 1024,
+      getResponseBody: async () => ({ body: '{"ok":true}', base64Encoded: false }),
+      onExchange: (e) => exchanges.push(e),
+    });
+    r.onRequestWillBeSent({
+      requestId: "1",
+      loaderId: "L",
+      documentURL: "https://example.com",
+      timestamp: 1.0,
+      wallTime: 1700000000,
+      request: {
+        method: "GET",
+        url: "https://example.com/api",
+        headers: { Accept: "application/json" },
+      },
+    });
+    r.onResponseReceived({
+      requestId: "1",
+      loaderId: "L",
+      timestamp: 1.05,
+      type: "XHR",
+      response: {
+        url: "https://example.com/api",
+        status: 200,
+        statusText: "OK",
+        headers: { "Content-Type": "application/json" },
+        mimeType: "application/json",
+      },
+    });
+    await r.onLoadingFinished({ requestId: "1", timestamp: 1.1, encodedDataLength: 11 });
+
+    expect(exchanges).toHaveLength(1);
+    expect(exchanges[0]!.request.method).toBe("GET");
+    expect(exchanges[0]!.response.status).toBe(200);
+    expect(exchanges[0]!.response.body).toEqual({ ok: true });
+  });
+
+  test("redirect emits two exchanges with the same requestId", async () => {
+    const exchanges: Omit<HttpExchange, "index">[] = [];
+    const r = new CdpReconstructor({
+      bodyMaxBytes: 1024,
+      getResponseBody: async () => ({ body: "ok", base64Encoded: false }),
+      onExchange: (e) => exchanges.push(e),
+    });
+    r.onRequestWillBeSent({
+      requestId: "1",
+      loaderId: "L",
+      documentURL: "https://example.com",
+      timestamp: 1.0,
+      wallTime: 1700000000,
+      request: { method: "GET", url: "https://example.com/old", headers: {} },
+    });
+    r.onRequestWillBeSent({
+      requestId: "1",
+      loaderId: "L",
+      documentURL: "https://example.com",
+      timestamp: 1.05,
+      wallTime: 1700000000,
+      request: { method: "GET", url: "https://example.com/new", headers: {} },
+      redirectResponse: {
+        url: "https://example.com/old",
+        status: 301,
+        statusText: "Moved",
+        headers: { Location: "/new" },
+        mimeType: "text/html",
+      },
+    });
+    r.onResponseReceived({
+      requestId: "1",
+      loaderId: "L",
+      timestamp: 1.1,
+      type: "Document",
+      response: {
+        url: "https://example.com/new",
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        mimeType: "text/plain",
+      },
+    });
+    await r.onLoadingFinished({ requestId: "1", timestamp: 1.2, encodedDataLength: 2 });
+
+    expect(exchanges).toHaveLength(2);
+    expect(exchanges[0]!.request.url).toBe("https://example.com/old");
+    expect(exchanges[0]!.response.status).toBe(301);
+    expect(exchanges[1]!.request.url).toBe("https://example.com/new");
+    expect(exchanges[1]!.response.status).toBe(200);
+  });
+
+  test("loadingFailed emits a synthetic error exchange", () => {
+    const exchanges: Omit<HttpExchange, "index">[] = [];
+    const r = new CdpReconstructor({
+      bodyMaxBytes: 1024,
+      getResponseBody: async () => null,
+      onExchange: (e) => exchanges.push(e),
+    });
+    r.onRequestWillBeSent({
+      requestId: "x",
+      loaderId: "L",
+      documentURL: "https://example.com",
+      timestamp: 1.0,
+      wallTime: 1700000000,
+      request: { method: "GET", url: "https://example.com/dead", headers: {} },
+    });
+    r.onLoadingFailed({
+      requestId: "x",
+      timestamp: 1.5,
+      type: "XHR",
+      errorText: "net::ERR_CONNECTION_RESET",
+    });
+    expect(exchanges).toHaveLength(1);
+    expect(exchanges[0]!.response.status).toBe(0);
+    expect(exchanges[0]!.response.headers["x-extension-error"]).toBe("net::ERR_CONNECTION_RESET");
+  });
+
+  test("binary response body is replaced with marker, not retained", async () => {
+    const exchanges: Omit<HttpExchange, "index">[] = [];
+    const r = new CdpReconstructor({
+      bodyMaxBytes: 4096,
+      getResponseBody: async () => ({ body: btoa("\x00\x01\x02\x03"), base64Encoded: true }),
+      onExchange: (e) => exchanges.push(e),
+    });
+    r.onRequestWillBeSent({
+      requestId: "b",
+      loaderId: "L",
+      documentURL: "https://example.com",
+      timestamp: 1.0,
+      wallTime: 1700000000,
+      request: { method: "GET", url: "https://example.com/img.png", headers: {} },
+    });
+    r.onResponseReceived({
+      requestId: "b",
+      loaderId: "L",
+      timestamp: 1.05,
+      type: "Image",
+      response: {
+        url: "https://example.com/img.png",
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        mimeType: "image/png",
+      },
+    });
+    await r.onLoadingFinished({ requestId: "b", timestamp: 1.1, encodedDataLength: 4 });
+    expect(exchanges).toHaveLength(1);
+    expect(exchanges[0]!.response.body).toMatchObject({ __binary: true, mediaType: "image/png" });
+  });
+});

--- a/browser-extension/test/har-emit.test.ts
+++ b/browser-extension/test/har-emit.test.ts
@@ -1,0 +1,56 @@
+// Round-trip: HttpExchange[] → emitHar → JSON → re-parse → confirm the
+// shape matches what the host's importHar (HAR 1.2) expects.
+
+import { describe, test, expect } from "vitest";
+import { emitHar } from "../src/capture/har-emit.js";
+import type { HttpExchange } from "../src/shared/types.js";
+
+const sample: HttpExchange = {
+  index: 0,
+  request: {
+    method: "POST",
+    url: "https://api.stripe.com/v1/customers?expand[]=invoice",
+    headers: { Authorization: "{{auth}}", "Content-Type": "application/json" },
+    body: { email: "alice@acme.com" },
+    timestamp: "2026-05-02T15:30:11.123Z",
+  },
+  response: {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    body: { id: "cus_abc" },
+    durationMs: 142,
+  },
+};
+
+describe("emitHar", () => {
+  test("emits HAR 1.2 with creator info", () => {
+    const har = emitHar([sample]);
+    expect(har.log.version).toBe("1.2");
+    expect(har.log.creator.name).toBe("specialist-extension");
+    expect(har.log.entries).toHaveLength(1);
+  });
+
+  test("queryString is extracted from URL", () => {
+    const har = emitHar([sample]);
+    expect(har.log.entries[0]!.request.queryString).toEqual([{ name: "expand[]", value: "invoice" }]);
+  });
+
+  test("postData/text is JSON-stringified", () => {
+    const har = emitHar([sample]);
+    expect(har.log.entries[0]!.request.postData?.text).toBe('{"email":"alice@acme.com"}');
+  });
+
+  test("response content.text is JSON-stringified", () => {
+    const har = emitHar([sample]);
+    expect(har.log.entries[0]!.response.content.text).toBe('{"id":"cus_abc"}');
+  });
+
+  test("string body is preserved verbatim", () => {
+    const x: HttpExchange = {
+      ...sample,
+      request: { ...sample.request, body: "raw=text&other=value", headers: { "Content-Type": "application/x-www-form-urlencoded" } },
+    };
+    const har = emitHar([x]);
+    expect(har.log.entries[0]!.request.postData?.text).toBe("raw=text&other=value");
+  });
+});

--- a/browser-extension/test/scrub.test.ts
+++ b/browser-extension/test/scrub.test.ts
@@ -1,0 +1,22 @@
+// Browser-side runner for the shared scrub fixture
+// `../../test/fixtures/scrub-cases.json`. Same cases as the host runner.
+
+import { describe, test, expect } from "vitest";
+import fixture from "../../test/fixtures/scrub-cases.json" with { type: "json" };
+import { scrubBody, scrubHeaders } from "../src/capture/scrub.js";
+
+describe("scrubHeaders", () => {
+  for (const c of fixture.headerCases) {
+    test(c.name, () => {
+      expect(scrubHeaders(c.input)).toEqual(c.expected);
+    });
+  }
+});
+
+describe("scrubBody", () => {
+  for (const c of fixture.bodyCases) {
+    test(c.name, () => {
+      expect(scrubBody(c.input)).toEqual(c.expected);
+    });
+  }
+});

--- a/browser-extension/test/scrub.test.ts
+++ b/browser-extension/test/scrub.test.ts
@@ -8,7 +8,7 @@ import { scrubBody, scrubHeaders } from "../src/capture/scrub.js";
 describe("scrubHeaders", () => {
   for (const c of fixture.headerCases) {
     test(c.name, () => {
-      expect(scrubHeaders(c.input)).toEqual(c.expected);
+      expect(scrubHeaders(c.input as unknown as Record<string, string>)).toEqual(c.expected);
     });
   }
 });

--- a/browser-extension/tsconfig.json
+++ b/browser-extension/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": false,
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "types": ["chrome", "vite/client", "vitest/globals"]
+  },
+  "include": ["src/**/*", "test/**/*", "manifest.config.ts", "vite.config.ts"],
+  "exclude": ["node_modules", "dist", "vendor"]
+}

--- a/browser-extension/tsconfig.json
+++ b/browser-extension/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ES2022",
+    "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",

--- a/browser-extension/vite.config.ts
+++ b/browser-extension/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { crx } from "@crxjs/vite-plugin";
+import manifest from "./manifest.config";
+
+export default defineConfig({
+  plugins: [react(), crx({ manifest })],
+  build: {
+    target: "esnext",
+    sourcemap: true,
+    rollupOptions: {
+      input: {
+        offscreen: "src/offscreen/recorder.html",
+      },
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["test/**/*.test.ts", "test/**/*.test.tsx"],
+  },
+});

--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -1,10 +1,11 @@
 # Capturing HTTP traces
 
-The agent learns from HTTP traces. The architecture doc lists three capture surfaces; this repo ships full support for two and a recipe for the third.
+The agent learns from HTTP traces. There are four capture surfaces.
 
 | Surface             | What for                                              | Status                            |
 | ------------------- | ----------------------------------------------------- | --------------------------------- |
 | Browser DevTools HAR| Web-app workflows the user drives in a browser       | Use `importHar()` / `--har=...`   |
+| Browser extension   | Same workflows, no DevTools dance — Chrome MV3 capture surface that emits a bundle file | `browser-extension/` (Chrome v1, Firefox v1.1) → `--bundle=...` |
 | MITM proxy HAR      | Native/desktop apps, mobile apps, anything not in DevTools | Use `importHar()` / `--har=...` |
 | `attachFetchInterceptor()` | Embedded inside a Node host that already makes the calls | First-class API in `src/capture/` |
 
@@ -39,7 +40,30 @@ This is the easiest path for SaaS apps.
 
 ---
 
-## Surface 2: MITM proxy
+## Surface 2: Browser extension (Chrome)
+
+A first-party Chrome extension lives in `browser-extension/`. It captures the network conversation via the Chrome DevTools Protocol — same data DevTools sees, but driven by an action-bar popup and packaged as a single JSON `bundle`.
+
+```bash
+# 1. Build + install the extension (see browser-extension/README.md).
+# 2. Click the action icon → Start. Drive your workflow. Click Stop.
+# 3. Edit the intent + (optional) voice narration in the popup.
+# 4. Click "Download bundle" → save the .json somewhere.
+
+specialist-agent learn \
+  --tenant=tenants/acme \
+  --bundle=~/Downloads/specialist-bundle-20260502T153011Z-a3b9k2.json
+```
+
+`--bundle` and `--har` are mutually exclusive; intent comes from the bundle itself, so don't pass `--intent` with `--bundle`.
+
+The extension scrubs auth on the way in using the same scrub rules as `src/capture/scrub.ts`. The shared fixture `test/fixtures/scrub-cases.json` is asserted by both copies in CI.
+
+See [`browser-extension/README.md`](../browser-extension/README.md) for build, install, and the bundle schema.
+
+---
+
+## Surface 3: MITM proxy
 
 For non-browser apps (desktop, native, mobile, server-to-server). Common tools:
 
@@ -80,7 +104,7 @@ File → Export → HAR.
 
 ---
 
-## Surface 3: SDK fetch interceptor (embedded use)
+## Surface 4: SDK fetch interceptor (embedded use)
 
 When the agent is embedded inside a Node host that *already* makes the API calls (e.g. an internal automation service), capture happens inline. No external proxy or browser needed.
 

--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -42,14 +42,19 @@ This is the easiest path for SaaS apps.
 
 ## Surface 2: Browser extension (Chrome)
 
-A first-party Chrome extension lives in `browser-extension/`. It captures the network conversation via the Chrome DevTools Protocol — same data DevTools sees, but driven by an action-bar popup and packaged as a single JSON `bundle`.
+A first-party Chrome extension lives in `browser-extension/`. It captures the network conversation via the Chrome DevTools Protocol — same data DevTools sees, driven by an action-bar popup. **By default the extension auto-POSTs each bundle to the synthesis backend you configure in the options page**, so the user never has to deal with files on the happy path.
 
 ```bash
 # 1. Build + install the extension (see browser-extension/README.md).
-# 2. Click the action icon → Start. Drive your workflow. Click Stop.
-# 3. Edit the intent + (optional) voice narration in the popup.
-# 4. Click "Download bundle" → save the .json somewhere.
+# 2. Open the options page → paste the synthesis endpoint + bearer token.
+# 3. Click the action icon → Start. Drive your workflow. Click Stop.
+# 4. The bundle is automatically POSTed to {endpoint}/v1/bundles.
+#    The popup shows "Submitted to host (trace …)" with an optional learnUrl.
+```
 
+If no endpoint is configured (or the POST fails), the bundle falls back to a local download so a recording is never silently lost. In that case feed it to the host CLI manually:
+
+```bash
 specialist-agent learn \
   --tenant=tenants/acme \
   --bundle=~/Downloads/specialist-bundle-20260502T153011Z-a3b9k2.json

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "typecheck": "tsc --noEmit",
     "agent": "tsx src/cli/main.ts",
     "wrapper": "tsx src/cli/wrapper.ts",
-    "demo": "tsx examples/demo.ts"
+    "demo": "tsx examples/demo.ts",
+    "test": "tsx --test test/**/*.test.ts"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.13",

--- a/src/bundle/schema.ts
+++ b/src/bundle/schema.ts
@@ -1,0 +1,83 @@
+// Source-of-truth zod schema for the on-disk bundle that the browser
+// extension produces. Mirrored verbatim at
+// `browser-extension/src/bundle/schema.ts`. The shared fixture
+// `test/fixtures/bundle-example.json` is parsed by both copies; if
+// either drifts, CI fails.
+
+import { z } from "zod";
+
+const HarHeaderSchema = z.object({
+  name: z.string(),
+  value: z.string(),
+});
+
+const HarPostDataSchema = z.object({
+  mimeType: z.string(),
+  text: z.string(),
+});
+
+const HarContentSchema = z.object({
+  mimeType: z.string(),
+  text: z.string(),
+  size: z.number().optional(),
+});
+
+const HarEntrySchema = z.object({
+  startedDateTime: z.string(),
+  time: z.number(),
+  request: z.object({
+    method: z.string(),
+    url: z.string(),
+    httpVersion: z.string().optional(),
+    headers: z.array(HarHeaderSchema),
+    queryString: z.array(HarHeaderSchema).optional(),
+    cookies: z.array(HarHeaderSchema).optional(),
+    headersSize: z.number().optional(),
+    bodySize: z.number().optional(),
+    postData: HarPostDataSchema.optional(),
+  }),
+  response: z.object({
+    status: z.number(),
+    statusText: z.string().optional(),
+    httpVersion: z.string().optional(),
+    headers: z.array(HarHeaderSchema),
+    cookies: z.array(HarHeaderSchema).optional(),
+    headersSize: z.number().optional(),
+    bodySize: z.number().optional(),
+    redirectURL: z.string().optional(),
+    content: HarContentSchema,
+  }),
+  cache: z.record(z.unknown()).optional(),
+  timings: z.record(z.number()).optional(),
+});
+
+export const BundleSchema = z.object({
+  schemaVersion: z.literal("1"),
+  intent: z.string().min(1).max(2000),
+  narrative: z.string().max(50_000).optional(),
+  har: z.object({
+    log: z.object({
+      version: z.literal("1.2"),
+      creator: z.object({ name: z.string(), version: z.string() }),
+      browser: z.object({ name: z.string(), version: z.string() }).optional(),
+      pages: z.array(z.unknown()).optional(),
+      entries: z.array(HarEntrySchema),
+    }),
+  }),
+  audio: z
+    .object({
+      mimeType: z.string(),
+      base64: z.string(),
+      durationMs: z.number(),
+    })
+    .nullable(),
+  metadata: z.object({
+    capturedBy: z.literal("specialist-extension"),
+    extensionVersion: z.string(),
+    browser: z.string(),
+    capturedAt: z.string(),
+    tabUrl: z.string().optional(),
+  }),
+});
+
+export type Bundle = z.infer<typeof BundleSchema>;

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -9,16 +9,20 @@
 // The "run" command starts a Claude Agent SDK session against the tenant's
 // skill set. "log" tails the git history of skill changes.
 
+import { promises as fs } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
 import { SpecialistAgent } from "../agent.js";
 import { TenantWorkspace } from "../tenant/workspace.js";
 import { importHar } from "../capture/har.js";
-import type { ParameterDecision } from "../types.js";
+import { BundleSchema } from "../bundle/schema.js";
+import type { HttpTrace, ParameterDecision } from "../types.js";
 
 interface Flags {
   tenant?: string;
   har?: string;
+  bundle?: string;
   intent?: string;
   model?: string;
   yes?: boolean;
@@ -44,10 +48,18 @@ function parseFlags(argv: string[]): Flags {
 
 async function cmdLearn(flags: Flags): Promise<void> {
   if (!flags.tenant) die("missing --tenant=<path>");
-  if (!flags.har) die("missing --har=<file> (HAR export from browser DevTools, MITM, or extension)");
-  if (!flags.intent) die("missing --intent=\"<one-sentence task description>\"");
+  if (flags.bundle && flags.har) die("--bundle and --har are mutually exclusive");
+  if (flags.bundle && flags.intent) {
+    die("--intent collides with bundle.intent; remove --intent or omit --bundle");
+  }
+  if (!flags.bundle && !flags.har) {
+    die("missing --bundle=<file> (extension capture) or --har=<file> + --intent=\"...\"");
+  }
+  if (flags.har && !flags.intent) die("missing --intent=\"<one-sentence task description>\"");
 
-  const trace = await importHar(flags.har!, flags.intent!);
+  const trace: HttpTrace = flags.bundle
+    ? await loadBundleTrace(flags.bundle)
+    : await importHar(flags.har!, flags.intent!);
   const agent = new SpecialistAgent({
     tenant: { id: path.basename(flags.tenant!), workspacePath: path.resolve(flags.tenant!) },
     ...(flags.model ? { model: flags.model } : {}),
@@ -71,6 +83,22 @@ async function cmdLearn(flags: Flags): Promise<void> {
   console.log(`\nSynthesized workflow: ${result.workflow}`);
   console.log(`Wrappers: ${result.wrappers.join(", ") || "(none new)"}`);
   if (result.commit) console.log(`Commit: ${result.commit.slice(0, 12)}`);
+}
+
+async function loadBundleTrace(bundlePath: string): Promise<HttpTrace> {
+  const raw = await fs.readFile(bundlePath, "utf8");
+  const bundle = BundleSchema.parse(JSON.parse(raw));
+  const tmp = path.join(os.tmpdir(), `specialist-bundle-${Date.now()}.har`);
+  await fs.writeFile(tmp, JSON.stringify(bundle.har));
+  try {
+    const trace = await importHar(tmp, bundle.intent);
+    if (bundle.narrative) {
+      trace.intent = `${bundle.intent}\n\n[narration: ${bundle.narrative}]`;
+    }
+    return trace;
+  } finally {
+    await fs.unlink(tmp).catch(() => {});
+  }
 }
 
 function renderObserved(value: unknown): string {
@@ -152,7 +180,7 @@ async function main() {
       return cmdLog(flags);
     default:
       console.error("usage: specialist-agent <learn|run|log> [flags]");
-      console.error("  learn --tenant=<path> --har=<file> --intent=\"...\" [--auto-keep]");
+      console.error("  learn --tenant=<path> (--bundle=<file> | --har=<file> --intent=\"...\") [--auto-keep]");
       console.error("  run   --tenant=<path> [--yes] \"<prompt>\"");
       console.error("  log   --tenant=<path>");
       process.exit(2);

--- a/test/bundle-schema.test.ts
+++ b/test/bundle-schema.test.ts
@@ -1,0 +1,26 @@
+// The shared `test/fixtures/bundle-example.json` must parse against the
+// host's BundleSchema. The browser-extension copy of BundleSchema
+// validates the same fixture in its own test suite.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { BundleSchema } from "../src/bundle/schema.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const raw = readFileSync(path.join(here, "fixtures", "bundle-example.json"), "utf8");
+
+test("BundleSchema parses the shared fixture", () => {
+  const parsed = BundleSchema.parse(JSON.parse(raw));
+  assert.equal(parsed.schemaVersion, "1");
+  assert.equal(parsed.metadata.capturedBy, "specialist-extension");
+  assert.equal(parsed.har.log.entries.length, 1);
+});
+
+test("BundleSchema rejects wrong schemaVersion", () => {
+  const parsed = JSON.parse(raw);
+  parsed.schemaVersion = "2";
+  assert.throws(() => BundleSchema.parse(parsed));
+});

--- a/test/fixtures/bundle-example.json
+++ b/test/fixtures/bundle-example.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": "1",
+  "intent": "Onboard a new enterprise customer with first invoice",
+  "narrative": "Customer first; for enterprise we always set collection_method to send_invoice. Then invoice item, then finalize the invoice.",
+  "har": {
+    "log": {
+      "version": "1.2",
+      "creator": { "name": "specialist-extension", "version": "0.1.0" },
+      "entries": [
+        {
+          "startedDateTime": "2026-05-02T15:30:11.123Z",
+          "time": 142,
+          "request": {
+            "method": "POST",
+            "url": "https://api.stripe.com/v1/customers",
+            "httpVersion": "HTTP/1.1",
+            "headers": [
+              { "name": "Authorization", "value": "{{auth}}" },
+              { "name": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "queryString": [],
+            "cookies": [],
+            "headersSize": -1,
+            "bodySize": -1,
+            "postData": {
+              "mimeType": "application/x-www-form-urlencoded",
+              "text": "email=alice%40acme.com&name=Acme+Inc"
+            }
+          },
+          "response": {
+            "status": 200,
+            "statusText": "",
+            "httpVersion": "HTTP/1.1",
+            "headers": [{ "name": "Content-Type", "value": "application/json" }],
+            "cookies": [],
+            "headersSize": -1,
+            "bodySize": -1,
+            "redirectURL": "",
+            "content": {
+              "mimeType": "application/json",
+              "text": "{\"id\":\"cus_NffrFeUfNV2Hib\",\"email\":\"alice@acme.com\"}"
+            }
+          },
+          "cache": {},
+          "timings": { "send": 0, "wait": 142, "receive": 0 }
+        }
+      ]
+    }
+  },
+  "audio": null,
+  "metadata": {
+    "capturedBy": "specialist-extension",
+    "extensionVersion": "0.1.0",
+    "browser": "chrome/120",
+    "capturedAt": "2026-05-02T15:30:11.000Z",
+    "tabUrl": "https://dashboard.stripe.com/test/customers"
+  }
+}

--- a/test/fixtures/scrub-cases.json
+++ b/test/fixtures/scrub-cases.json
@@ -1,0 +1,152 @@
+{
+  "$comment": "Shared scrub-behavior fixture used by BOTH src/capture/scrub.ts (host, Vitest) AND browser-extension/src/capture/scrub.ts (extension, Vitest). If either copy of scrub.ts drifts, the corresponding test fails. Cases are written as {input, expected} for either headers or body — the runner picks based on which key is present.",
+  "headerCases": [
+    {
+      "name": "authorization header replaced",
+      "input": { "Authorization": "Bearer sk_live_abc123" },
+      "expected": { "Authorization": "{{auth}}" }
+    },
+    {
+      "name": "case-insensitive match (lowercased key)",
+      "input": { "authorization": "Bearer foo" },
+      "expected": { "authorization": "{{auth}}" }
+    },
+    {
+      "name": "x-api-key replaced",
+      "input": { "x-api-key": "abcdef" },
+      "expected": { "x-api-key": "{{auth}}" }
+    },
+    {
+      "name": "api-key replaced",
+      "input": { "api-key": "abcdef" },
+      "expected": { "api-key": "{{auth}}" }
+    },
+    {
+      "name": "x-auth-token replaced",
+      "input": { "X-Auth-Token": "tok" },
+      "expected": { "X-Auth-Token": "{{auth}}" }
+    },
+    {
+      "name": "x-access-token replaced",
+      "input": { "x-access-token": "tok" },
+      "expected": { "x-access-token": "{{auth}}" }
+    },
+    {
+      "name": "cookie replaced",
+      "input": { "Cookie": "session=abc" },
+      "expected": { "Cookie": "{{auth}}" }
+    },
+    {
+      "name": "set-cookie replaced",
+      "input": { "Set-Cookie": "session=abc; HttpOnly" },
+      "expected": { "Set-Cookie": "{{auth}}" }
+    },
+    {
+      "name": "proxy-authorization replaced",
+      "input": { "proxy-authorization": "Basic ZGVtbzpkZW1v" },
+      "expected": { "proxy-authorization": "{{auth}}" }
+    },
+    {
+      "name": "non-auth headers passed through",
+      "input": { "Content-Type": "application/json", "X-Trace-Id": "abc" },
+      "expected": { "Content-Type": "application/json", "X-Trace-Id": "abc" }
+    },
+    {
+      "name": "mixed header object",
+      "input": { "Authorization": "Bearer x", "Content-Type": "text/plain" },
+      "expected": { "Authorization": "{{auth}}", "Content-Type": "text/plain" }
+    }
+  ],
+  "bodyCases": [
+    {
+      "name": "null is null",
+      "input": null,
+      "expected": null
+    },
+    {
+      "name": "undefined is preserved as null",
+      "input": null,
+      "expected": null
+    },
+    {
+      "name": "primitive number passes through",
+      "input": 42,
+      "expected": 42
+    },
+    {
+      "name": "primitive boolean passes through",
+      "input": true,
+      "expected": true
+    },
+    {
+      "name": "string with embedded bearer",
+      "input": "grant_type=refresh&refresh_token=abc Bearer eyJhbG.foo-bar_baz",
+      "expected": "grant_type=refresh&refresh_token=abc Bearer {{auth}}"
+    },
+    {
+      "name": "string without bearer passes through",
+      "input": "hello world",
+      "expected": "hello world"
+    },
+    {
+      "name": "json with api_key key",
+      "input": { "api_key": "shh" },
+      "expected": { "api_key": "{{auth}}" }
+    },
+    {
+      "name": "json with apikey key",
+      "input": { "apikey": "shh" },
+      "expected": { "apikey": "{{auth}}" }
+    },
+    {
+      "name": "json with access_token",
+      "input": { "access_token": "shh" },
+      "expected": { "access_token": "{{auth}}" }
+    },
+    {
+      "name": "json with refresh_token",
+      "input": { "refresh_token": "shh" },
+      "expected": { "refresh_token": "{{auth}}" }
+    },
+    {
+      "name": "json with client_secret",
+      "input": { "client_secret": "shh" },
+      "expected": { "client_secret": "{{auth}}" }
+    },
+    {
+      "name": "json with password",
+      "input": { "password": "shh" },
+      "expected": { "password": "{{auth}}" }
+    },
+    {
+      "name": "json with secret",
+      "input": { "secret": "shh" },
+      "expected": { "secret": "{{auth}}" }
+    },
+    {
+      "name": "nested client_secret",
+      "input": { "auth": { "client_secret": "shh", "redirect_uri": "https://x" } },
+      "expected": { "auth": { "client_secret": "{{auth}}", "redirect_uri": "https://x" } }
+    },
+    {
+      "name": "array of objects",
+      "input": [{ "api_key": "k1" }, { "api_key": "k2" }],
+      "expected": [{ "api_key": "{{auth}}" }, { "api_key": "{{auth}}" }]
+    },
+    {
+      "name": "non-secret keys preserved",
+      "input": { "name": "alice", "email": "alice@example.com" },
+      "expected": { "name": "alice", "email": "alice@example.com" }
+    },
+    {
+      "name": "deep nesting",
+      "input": { "a": { "b": { "c": { "api_key": "shh", "ok": 1 } } } },
+      "expected": { "a": { "b": { "c": { "api_key": "{{auth}}", "ok": 1 } } } }
+    },
+    {
+      "name": "array with bearer string",
+      "input": ["Bearer abc.def-ghi", "no token here"],
+      "expected": ["Bearer {{auth}}", "no token here"]
+    }
+  ]
+}

--- a/test/scrub-fixture.test.ts
+++ b/test/scrub-fixture.test.ts
@@ -1,0 +1,34 @@
+// Host-side runner for the shared scrub fixture
+// `test/fixtures/scrub-cases.json`. The browser-extension copy of
+// `scrub.ts` runs the SAME fixture under Vitest. If either drifts, CI
+// fails. Uses node:test (built into Node 20+) to avoid adding a new
+// dependency to the host package.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { scrubBody, scrubHeaders } from "../src/capture/scrub.js";
+
+interface Fixture {
+  headerCases: Array<{ name: string; input: Record<string, string>; expected: Record<string, string> }>;
+  bodyCases: Array<{ name: string; input: unknown; expected: unknown }>;
+}
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fixture = JSON.parse(
+  readFileSync(path.join(here, "fixtures", "scrub-cases.json"), "utf8"),
+) as Fixture;
+
+for (const c of fixture.headerCases) {
+  test(`scrubHeaders: ${c.name}`, () => {
+    assert.deepStrictEqual(scrubHeaders(c.input), c.expected);
+  });
+}
+
+for (const c of fixture.bodyCases) {
+  test(`scrubBody: ${c.name}`, () => {
+    assert.deepStrictEqual(scrubBody(c.input), c.expected);
+  });
+}


### PR DESCRIPTION
Implements `prompts/PLANS/browser-extension.md` — a Chrome MV3 extension that captures HTTP workflows via the DevTools Protocol and emits a portable bundle JSON file the host CLI consumes through a new `--bundle` flag.

## Summary

- **`browser-extension/`** — full Chrome MV3 extension
  - Service worker (`src/background/`): `chrome.debugger` + `Network.*` events flow through a pure `CdpReconstructor` state machine that handles redirects, extra-info race windows, binary bodies (replaced with marker, never persisted), and `loadingFailed` synthetic exchanges. Auth is scrubbed on the way in.
  - Offscreen document (`src/offscreen/`) hosts `MediaRecorder` (SW can't) + Web Speech API live transcription. Whisper.wasm slot is stubbed for v1.1.
  - React popup (`src/popup/`) with Start/Stop, live stats, host filter, intent + narration editor, Download/POST/Discard menu.
  - Options page (`src/options/`) for POST endpoint, bearer token, body cap, host allowlist, transcriber choice.
  - Content script (`src/content/banner.ts`) renders a friendly "Recording" overlay with a Stop button atop Chrome's yellow CDP banner.
  - Bundle (`src/bundle/`) produces HAR 1.2 inside a zod-validated envelope; saves via `chrome.downloads` or POSTs to `{endpoint}/v1/bundles`.
- **Host integration**
  - `src/bundle/schema.ts` — zod `BundleSchema` mirrored from the extension copy.
  - `src/cli/main.ts` — new `--bundle=<file>` flag, mutually exclusive with `--har/--intent`. Reads bundle, writes the HAR section to a temp file, hands it through the existing `importHar` pipeline, prepends narration if present.
- **Shared fixtures + dual tests**
  - `test/fixtures/scrub-cases.json` (29 cases) asserted by `test/scrub-fixture.test.ts` (host, `node:test`) AND `browser-extension/test/scrub.test.ts` (extension, vitest).
  - `test/fixtures/bundle-example.json` parsed by both copies of `BundleSchema`.
  - Extension-side: `cdp-reconstruct.test.ts` (single GET, redirect, loadingFailed, binary body), `har-emit.test.ts`, `bundle-build.test.ts`.
- **Docs** — `browser-extension/README.md`, updates to `docs/CAPTURE.md` (now lists 4 surfaces) and the top-level `README.md`.

## Test plan

- [x] `npm run typecheck` — host typecheck clean
- [x] `npm test` — 31 host tests pass (29 scrub fixture + 2 bundle schema)
- [x] End-to-end: `BundleSchema.parse` → `importHar` round-trip on the shared fixture produces the expected `HttpTrace`
- [x] CLI help renders the new `--bundle` form
- [ ] `cd browser-extension && npm install && npm run typecheck && npm test` — needs running once dependencies install in CI
- [ ] Manual: load `browser-extension/dist` as unpacked extension and capture a Stripe sandbox workflow end-to-end

## Notable deferrals (per plan)

- Firefox adapter (v1.1)
- Whisper.wasm vendor file (v1.1; lazy-load slot is wired)
- Multi-tab merge (v1.1)
- Server-side `/v1/bundles` endpoint (out of scope for this PR; client wire is complete)

https://claude.ai/code/session_01AieyEWpygA38wNARESAv6x

---
_Generated by [Claude Code](https://claude.ai/code/session_01AieyEWpygA38wNARESAv6x)_