### PR TITLE
Add multi-tenant synthesis backend (Railway-deployable)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.6
+FROM node:20-slim AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts
+
+FROM node:20-slim AS dev-deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+FROM node:20-slim AS runtime
+WORKDIR /app
+# git is required at runtime — every tenant workspace is a git repo and
+# the agent commits skills on each successful synthesis.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV NODE_ENV=production
+ENV PORT=3000
+
+# Source + tsx (kept in node_modules for runtime via dev-deps stage,
+# since we ship TS directly rather than precompile).
+COPY --from=dev-deps /app/node_modules ./node_modules
+COPY package.json package-lock.json tsconfig.json ./
+COPY src ./src
+
+# Drop privileges. Tenant volume is mounted read-write at the path
+# Railway exposes via RAILWAY_VOLUME_MOUNT_PATH; chown is applied by
+# Railway on volume attach.
+RUN useradd -r -u 10001 specialist && chown -R specialist /app
+USER specialist
+
+EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||3000)+'/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["npx", "tsx", "src/server/main.ts"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A learning agent built on the [Claude Agent SDK](https://docs.claude.com/en/agen
 | [`docs/USAGE.md`](docs/USAGE.md)          | End-to-end real-world walkthrough — capture → synthesize → run          |
 | [`docs/CAPTURE.md`](docs/CAPTURE.md)      | Four ways to capture HTTP traces: DevTools HAR, browser extension, MITM proxy, SDK hook |
 | [`browser-extension/README.md`](browser-extension/README.md) | Chrome MV3 extension that captures workflows and emits a bundle file the host CLI consumes via `--bundle=` |
+| [`docs/SERVER.md`](docs/SERVER.md)        | Multi-tenant synthesis backend (`src/server/`) — receives bundles from the extension, runs `learnFromTrace`, commits to the tenant repo. Railway-deployable. |
 | [`docs/EMBEDDING.md`](docs/EMBEDDING.md)  | Programmatic API for embedding the agent in your own host application  |
 | [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) | Common errors and fixes                                       |
 | [`prompts/`](prompts/)                    | Briefing prompts for follow-up planning agents (next features)          |

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -96,7 +96,7 @@ Content-Type: application/json
 Authorization: Bearer {postBearerToken}     (omitted if blank)
 ```
 
-Server contract is documented in [`prompts/PLANS/browser-extension.md`](../prompts/PLANS/browser-extension.md) §7.2; the endpoint itself is out of scope for the extension. On any failure the extension writes a local download instead and exposes a Retry button — the user never has to manually export a file under the happy path.
+A reference implementation of the receiving server lives in this repo at [`src/server/`](../src/server/) — multi-tenant, Railway-deployable, runs `agent.learnFromTrace` on each accepted bundle. See [`docs/SERVER.md`](../docs/SERVER.md) for endpoint details and the deploy guide. On any failure the extension writes a local download instead and exposes a Retry button — the user never has to manually export a file under the happy path.
 
 ## Layout
 

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -1,0 +1,112 @@
+# Synthesis backend
+
+A small HTTP server that turns a [browser-extension](../browser-extension/README.md) bundle into committed skills on the tenant's git repo. Lives at [`src/server/`](../src/server/).
+
+```
+extension → POST /v1/bundles → BundleSchema.parse → importHar →
+  agent.learnFromTrace → git commit on tenant branch → 200 { workflow, wrappers, commit, traceId }
+```
+
+The server is the **only** auto-trigger for `learnFromTrace` — same code path as the CLI's `learn --bundle=...`, just wrapped in HTTP + multi-tenant auth + a Railway volume guard.
+
+## Local development
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+export RAILWAY_VOLUME_MOUNT_PATH=$PWD/.local-volume
+export BUNDLE_TOKENS="dev-token:$RAILWAY_VOLUME_MOUNT_PATH/tenants/local"
+mkdir -p "$RAILWAY_VOLUME_MOUNT_PATH/tenants/local"
+npm run server
+```
+
+Smoke-test with the bundled fixture:
+
+```bash
+curl -X POST http://localhost:3000/v1/bundles \
+  -H "Authorization: Bearer dev-token" \
+  -H "Content-Type: application/json" \
+  --data @test/fixtures/bundle-example.json
+```
+
+## Endpoints
+
+### `POST /v1/bundles`
+
+Body: a [`Bundle`](../src/bundle/schema.ts) — same shape the extension produces. Headers:
+
+```
+Authorization: Bearer <token>     (required; resolves to a tenant)
+Content-Type:  application/json
+```
+
+Synchronous. Synthesis takes 30–90s for typical traces because it makes one Claude call.
+
+```jsonc
+// 200
+{
+  "accepted": true,
+  "traceId": "5a7f3e2b-...",
+  "workflow": "onboard_enterprise",
+  "wrappers": ["create_customer", "create_invoice"],
+  "commit": "deadbeef",
+  "tenant": "acme"
+}
+
+// 400 invalid_bundle  → schema validation failed; `detail` lists the failing paths
+// 401 unauthorized    → bearer missing or unknown
+// 413 bundle_too_large → exceeds 50 MiB (configurable per-instance)
+// 500 synthesis_failed → see `detail`
+```
+
+### `GET /healthz`
+
+Liveness probe. Returns the configured tenant count and volume mount so misconfiguration is visible at a glance.
+
+```jsonc
+{ "status": "ok", "tenants": 3, "volumeRoot": "/data" }
+```
+
+## Configuration (env)
+
+| Var | Required | Purpose |
+| --- | --- | --- |
+| `ANTHROPIC_API_KEY` | yes | Synthesis. Server refuses to start without it. |
+| `RAILWAY_VOLUME_MOUNT_PATH` | yes | Persistent volume root. **Server refuses to start if any tenant path resolves outside it** — guards against ephemeral container storage silently eating tenant git history. |
+| `BUNDLE_TOKENS` | yes | Bearer token → tenant-path map. Two accepted forms: <br>• CSV: `"tok-acme:/data/tenants/acme,tok-foo:/data/tenants/foo"` <br>• JSON: `'{"tok-acme":"/data/tenants/acme","tok-foo":"/data/tenants/foo"}'` |
+| `PORT` | no | Defaults to `3000`. Railway sets this. |
+| `SPECIALIST_MODEL` | no | Override the Claude model for synthesis. |
+
+Volume enforcement is strict: a token mapped to `/etc/passwd` (or `/tmp/somewhere`) when `RAILWAY_VOLUME_MOUNT_PATH=/data` makes the server exit `2` at boot. No silent demotion.
+
+## Deploy on Railway
+
+1. **Create the project** from this repo. Railway detects the `Dockerfile` automatically.
+2. **Add a volume.** Storage → New Volume, mount path `/data`. Railway sets `RAILWAY_VOLUME_MOUNT_PATH=/data` for the service.
+3. **Set env vars** (Variables tab):
+   ```
+   ANTHROPIC_API_KEY=sk-ant-...
+   BUNDLE_TOKENS={"tok-acme":"/data/tenants/acme","tok-foo":"/data/tenants/foo"}
+   ```
+   Pick tokens with at least 32 bytes of entropy (`openssl rand -hex 32`).
+4. **Deploy.** Railway exposes a public URL like `https://specialist-server.up.railway.app`.
+5. **Configure each extension user.** Options page → POST endpoint = `https://specialist-server.up.railway.app`, bearer token = the value mapped to their tenant in `BUNDLE_TOKENS`.
+
+**Adding a tenant later:** edit `BUNDLE_TOKENS`, redeploy. The new tenant directory is created on first boot. Existing tenants are unaffected — their git history lives on the volume and survives the redeploy.
+
+**Rotating a token:** add the new token alongside the old one in `BUNDLE_TOKENS`, redeploy, distribute, then remove the old token in a follow-up redeploy.
+
+## Self-improvement
+
+Every successful POST commits new wrappers + a workflow on a synth branch and merges to `main` if replay passes. The CLI runs the same agent against the same tenant repo — agent learns, git tracks, and `meta.update_skill` lets the agent reactively patch its own skills mid-task. There is no second control plane.
+
+```bash
+specialist-agent run --tenant=/data/tenants/acme "onboard a new customer at $5000 monthly"
+specialist-agent log --tenant=/data/tenants/acme    # tail the audit log
+```
+
+## What's deliberately not here (yet)
+
+- **Async synthesis + status endpoint.** v1 blocks the POST for the full Claude call. If extension users hit timeouts the next iteration is `202 Accepted` + `GET /v1/traces/:id`.
+- **Per-tenant Anthropic keys.** v1 uses one platform key for all tenants.
+- **Webhook on completion.** Easy to add when async lands.
+- **Quotas / rate limiting.** Out of scope for v1.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.13",
         "@anthropic-ai/sdk": "^0.40.0",
+        "@hono/node-server": "^2.0.1",
+        "hono": "^4.12.16",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -517,6 +519,18 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.1.tgz",
+      "integrity": "sha512-jI9yMDyFpqBeSighf/zlXnQG/nl9AyBc6aAgy4XtxJMyt/CNyJpvPfzDD+bCc2zAOmhhqtF6TnmIaY+xV4mIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
@@ -1155,6 +1169,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/humanize-ms": {

--- a/package.json
+++ b/package.json
@@ -14,12 +14,15 @@
     "typecheck": "tsc --noEmit",
     "agent": "tsx src/cli/main.ts",
     "wrapper": "tsx src/cli/wrapper.ts",
+    "server": "tsx src/server/main.ts",
     "demo": "tsx examples/demo.ts",
     "test": "tsx --test test/**/*.test.ts"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.13",
     "@anthropic-ai/sdk": "^0.40.0",
+    "@hono/node-server": "^2.0.1",
+    "hono": "^4.12.16",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,0 +1,119 @@
+// Hono app factory. Separated from `main.ts` so tests can run the same
+// pipeline without binding a port.
+
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { cors } from "hono/cors";
+import { logger } from "hono/logger";
+import { SpecialistAgent } from "../agent.js";
+import { BundleSchema } from "../bundle/schema.js";
+import type { TenantConfig } from "../types.js";
+import { processBundle, type HandlerDeps } from "./handler.js";
+import { TenantResolver } from "./auth.js";
+
+export interface AppOptions {
+  resolver: TenantResolver;
+  /** Body-size cap in bytes. Defaults to 50 MiB to match plan §7.2 / 413. */
+  maxBodyBytes?: number;
+  /** Override the model passed to SpecialistAgent. */
+  model?: string;
+  /** Test seam — replace the real SpecialistAgent. */
+  agentFor?: HandlerDeps["agentFor"];
+  /** Test seam — disable request logger. */
+  logRequests?: boolean;
+}
+
+const DEFAULT_MAX_BYTES = 50 * 1024 * 1024;
+
+export function createApp(opts: AppOptions): Hono {
+  const app = new Hono();
+  const maxBodyBytes = opts.maxBodyBytes ?? DEFAULT_MAX_BYTES;
+
+  if (opts.logRequests !== false) {
+    app.use("*", logger());
+  }
+  app.use("*", cors({ origin: "*", allowHeaders: ["Authorization", "Content-Type"], allowMethods: ["POST", "GET", "OPTIONS"] }));
+
+  app.get("/healthz", (c) =>
+    c.json({
+      status: "ok",
+      tenants: opts.resolver.size,
+      volumeRoot: opts.resolver.volumeRoot,
+    }),
+  );
+
+  app.post("/v1/bundles", async (c) => {
+    const tenant = opts.resolver.resolveBearer(c.req.header("Authorization"));
+    if (!tenant) {
+      throw new HTTPException(401, {
+        message: JSON.stringify({ error: "unauthorized", detail: "missing or invalid bearer token" }),
+      });
+    }
+
+    const contentLength = Number(c.req.header("Content-Length") ?? 0);
+    if (contentLength > maxBodyBytes) {
+      throw new HTTPException(413, {
+        message: JSON.stringify({ error: "bundle_too_large", detail: `bundle exceeds ${maxBodyBytes} byte limit` }),
+      });
+    }
+
+    let raw: unknown;
+    try {
+      raw = await c.req.json();
+    } catch (err) {
+      throw new HTTPException(400, {
+        message: JSON.stringify({ error: "invalid_json", detail: (err as Error).message }),
+      });
+    }
+
+    const parsed = BundleSchema.safeParse(raw);
+    if (!parsed.success) {
+      throw new HTTPException(400, {
+        message: JSON.stringify({
+          error: "invalid_bundle",
+          detail: parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "),
+        }),
+      });
+    }
+
+    const agentFor: HandlerDeps["agentFor"] =
+      opts.agentFor ??
+      ((t: TenantConfig) =>
+        new SpecialistAgent({
+          tenant: t,
+          ...(opts.model ? { model: opts.model } : {}),
+        }));
+
+    const result = await processBundle(parsed.data, tenant.config, { agentFor });
+
+    if (result.ok) {
+      return c.json({
+        accepted: true,
+        traceId: result.traceId,
+        workflow: result.workflow,
+        wrappers: result.wrappers,
+        commit: result.commit,
+        tenant: result.tenant,
+      });
+    }
+    throw new HTTPException(result.status as 400 | 500, {
+      message: JSON.stringify({ error: result.error, detail: result.detail }),
+    });
+  });
+
+  // Hono's default error handler stringifies HTTPException.message into
+  // a text body. We want JSON with the right Content-Type on every
+  // error path — extension parses `error` + `detail`.
+  app.onError((err, c) => {
+    if (err instanceof HTTPException) {
+      try {
+        return c.json(JSON.parse(err.message), err.status);
+      } catch {
+        return c.json({ error: "internal", detail: err.message }, err.status);
+      }
+    }
+    return c.json({ error: "internal", detail: err.message }, 500);
+  });
+
+  return app;
+}

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,0 +1,140 @@
+// Bearer-token → tenant resolution + Railway volume enforcement.
+//
+// All tenant workspaces MUST live under RAILWAY_VOLUME_MOUNT_PATH so
+// that container restarts don't wipe per-tenant git history. The
+// resolver fails fast at startup — the server refuses to boot if any
+// configured tenant path resolves outside the volume.
+
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import type { TenantConfig } from "../types.js";
+
+export interface TenantResolverOptions {
+  /** Map of bearer token → tenant workspace path. */
+  tokens: Record<string, string>;
+  /** Required: every tenant path must resolve under this directory. */
+  volumeRoot: string;
+}
+
+export interface ResolvedTenant {
+  config: TenantConfig;
+  /** The bearer token that resolved to this tenant. */
+  token: string;
+}
+
+export class TenantResolver {
+  private readonly byToken: Map<string, TenantConfig>;
+  readonly volumeRoot: string;
+
+  constructor(opts: TenantResolverOptions) {
+    if (!opts.volumeRoot) {
+      throw new ConfigError(
+        "RAILWAY_VOLUME_MOUNT_PATH is not set. The server refuses to start without a persistent volume " +
+          "— tenant git history would be lost on every redeploy.",
+      );
+    }
+    if (Object.keys(opts.tokens).length === 0) {
+      throw new ConfigError(
+        "BUNDLE_TOKENS is empty. Configure at least one bearer-token → tenant-path mapping.",
+      );
+    }
+
+    const volumeRoot = path.resolve(opts.volumeRoot);
+    this.volumeRoot = volumeRoot;
+    this.byToken = new Map();
+
+    for (const [token, tenantPath] of Object.entries(opts.tokens)) {
+      const resolved = path.resolve(tenantPath);
+      if (!isUnder(resolved, volumeRoot)) {
+        throw new ConfigError(
+          `Tenant path "${tenantPath}" resolves to "${resolved}", which is not under the configured ` +
+            `volume "${volumeRoot}". Move the tenant directory inside the Railway volume.`,
+        );
+      }
+      this.byToken.set(token, {
+        id: path.basename(resolved),
+        workspacePath: resolved,
+      });
+    }
+  }
+
+  /**
+   * Look up a tenant from an `Authorization: Bearer <token>` header.
+   * Returns null if the header is missing/malformed or the token is
+   * unknown — caller should respond 401.
+   */
+  resolveBearer(authHeader: string | undefined): ResolvedTenant | null {
+    if (!authHeader) return null;
+    const m = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
+    if (!m) return null;
+    const token = m[1]!;
+    const config = this.byToken.get(token);
+    if (!config) return null;
+    return { config, token };
+  }
+
+  /**
+   * Idempotent: ensure every configured tenant directory exists.
+   * Volume root is already mounted by Railway; tenant subdirs may not
+   * exist yet on a fresh deploy.
+   */
+  async ensureTenantDirs(): Promise<void> {
+    for (const cfg of this.byToken.values()) {
+      await fs.mkdir(cfg.workspacePath, { recursive: true });
+    }
+  }
+
+  /** Number of configured tenants — useful for logging and health. */
+  get size(): number {
+    return this.byToken.size;
+  }
+}
+
+export class ConfigError extends Error {}
+
+function isUnder(child: string, parent: string): boolean {
+  const rel = path.relative(parent, child);
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+/**
+ * Parse the BUNDLE_TOKENS env var. Two accepted forms:
+ *   1. CSV: "token1:tenants/acme,token2:tenants/foo"
+ *   2. JSON: '{"token1":"tenants/acme","token2":"tenants/foo"}'
+ * Whitespace around tokens and paths is trimmed.
+ */
+export function parseBundleTokens(raw: string | undefined): Record<string, string> {
+  if (!raw) return {};
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("{")) {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new ConfigError("BUNDLE_TOKENS JSON must be an object of token → path");
+    }
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v !== "string") {
+        throw new ConfigError(`BUNDLE_TOKENS["${k}"] must be a string path`);
+      }
+      out[k.trim()] = v.trim();
+    }
+    return out;
+  }
+  const out: Record<string, string> = {};
+  for (const pair of trimmed.split(",")) {
+    if (!pair.trim()) continue;
+    const sep = pair.indexOf(":");
+    if (sep < 0) {
+      throw new ConfigError(
+        `BUNDLE_TOKENS entry "${pair}" must be of the form "<token>:<path>"`,
+      );
+    }
+    const token = pair.slice(0, sep).trim();
+    const tenantPath = pair.slice(sep + 1).trim();
+    if (!token || !tenantPath) {
+      throw new ConfigError(`BUNDLE_TOKENS entry "${pair}" is missing token or path`);
+    }
+    out[token] = tenantPath;
+  }
+  return out;
+}

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -1,0 +1,84 @@
+// Pure synthesis handler: validated bundle + resolved tenant → result.
+// No HTTP concerns here so it's trivially unit-testable.
+
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { SpecialistAgent } from "../agent.js";
+import { importHar } from "../capture/har.js";
+import type { Bundle } from "../bundle/schema.js";
+import type { TenantConfig } from "../types.js";
+
+export interface SynthesisOk {
+  ok: true;
+  accepted: true;
+  traceId: string;
+  workflow: string;
+  wrappers: string[];
+  commit: string;
+  tenant: string;
+}
+
+export interface SynthesisErr {
+  ok: false;
+  status: number;
+  error: string;
+  detail: string;
+}
+
+export type SynthesisResult = SynthesisOk | SynthesisErr;
+
+export interface HandlerDeps {
+  /**
+   * Factory so tests can stub the agent. Production wires
+   * `(t) => new SpecialistAgent({ tenant: t, ... })`.
+   */
+  agentFor: (tenant: TenantConfig) => Pick<SpecialistAgent, "learnFromTrace">;
+}
+
+/**
+ * Parse the bundle's HAR, hand it to the tenant's agent for synthesis,
+ * and return the names of the workflow + wrappers that were committed.
+ * `learnUrl` is left for the host to derive (e.g. Railway preview URL +
+ * `/v1/traces/<id>`); not produced here.
+ */
+export async function processBundle(
+  bundle: Bundle,
+  tenant: TenantConfig,
+  deps: HandlerDeps,
+): Promise<SynthesisResult> {
+  const traceId = randomUUID();
+  const tmpFile = path.join(os.tmpdir(), `specialist-bundle-${traceId}.har`);
+
+  try {
+    await fs.writeFile(tmpFile, JSON.stringify(bundle.har));
+    const trace = await importHar(tmpFile, bundle.intent);
+    if (bundle.narrative) {
+      trace.intent = `${bundle.intent}\n\n[narration: ${bundle.narrative}]`;
+    }
+    trace.id = traceId;
+
+    const agent = deps.agentFor(tenant);
+    const result = await agent.learnFromTrace(trace, { skipReplay: false });
+
+    return {
+      ok: true,
+      accepted: true,
+      traceId,
+      workflow: result.workflow,
+      wrappers: result.wrappers,
+      commit: result.commit,
+      tenant: tenant.id,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      status: 500,
+      error: "synthesis_failed",
+      detail: (err as Error).message,
+    };
+  } finally {
+    await fs.unlink(tmpFile).catch(() => {});
+  }
+}

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Server entry. Loads config from env, starts Hono on the configured
+// port, exits non-zero on misconfiguration so Railway flags the deploy.
+
+import { serve } from "@hono/node-server";
+import { createApp } from "./app.js";
+import { ConfigError, parseBundleTokens, TenantResolver } from "./auth.js";
+
+async function main(): Promise<void> {
+  const port = Number(process.env.PORT ?? 3000);
+  const volumeRoot = process.env.RAILWAY_VOLUME_MOUNT_PATH ?? "";
+  const tokens = parseBundleTokens(process.env.BUNDLE_TOKENS);
+  const model = process.env.SPECIALIST_MODEL || undefined;
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error("error: ANTHROPIC_API_KEY is not set — synthesis will fail.");
+    process.exit(2);
+  }
+
+  let resolver: TenantResolver;
+  try {
+    resolver = new TenantResolver({ tokens, volumeRoot });
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      console.error(`config error: ${err.message}`);
+      process.exit(2);
+    }
+    throw err;
+  }
+  await resolver.ensureTenantDirs();
+
+  const app = createApp({ resolver, ...(model ? { model } : {}) });
+
+  serve({ fetch: app.fetch, port }, ({ port: bound }) => {
+    console.log(
+      `[specialist-server] listening on :${bound} — ${resolver.size} tenant(s), volume=${resolver.volumeRoot}`,
+    );
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/server-handler.test.ts
+++ b/test/server-handler.test.ts
@@ -1,0 +1,245 @@
+// Server handler + auth + app — exercises each path with a stubbed
+// SpecialistAgent so we never hit the network during unit tests.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+import { processBundle } from "../src/server/handler.js";
+import { ConfigError, parseBundleTokens, TenantResolver } from "../src/server/auth.js";
+import { createApp } from "../src/server/app.js";
+import { BundleSchema, type Bundle } from "../src/bundle/schema.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.join(here, "fixtures", "bundle-example.json");
+
+async function loadBundle(): Promise<Bundle> {
+  const raw = await fs.readFile(fixturePath, "utf8");
+  return BundleSchema.parse(JSON.parse(raw));
+}
+
+async function makeVolume(): Promise<{ root: string; tenantPath: string; cleanup: () => Promise<void> }> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "specialist-test-volume-"));
+  const tenantPath = path.join(root, "tenants", "acme");
+  return {
+    root,
+    tenantPath,
+    cleanup: () => fs.rm(root, { recursive: true, force: true }),
+  };
+}
+
+test("parseBundleTokens — CSV form", () => {
+  const out = parseBundleTokens("t1:tenants/a, t2:tenants/b");
+  assert.deepStrictEqual(out, { t1: "tenants/a", t2: "tenants/b" });
+});
+
+test("parseBundleTokens — JSON form", () => {
+  const out = parseBundleTokens('{"t1":"tenants/a","t2":"tenants/b"}');
+  assert.deepStrictEqual(out, { t1: "tenants/a", t2: "tenants/b" });
+});
+
+test("parseBundleTokens — empty input", () => {
+  assert.deepStrictEqual(parseBundleTokens(undefined), {});
+  assert.deepStrictEqual(parseBundleTokens(""), {});
+});
+
+test("parseBundleTokens — malformed CSV throws", () => {
+  assert.throws(() => parseBundleTokens("noseparator"), ConfigError);
+});
+
+test("TenantResolver — refuses tenant outside volume", async () => {
+  const v = await makeVolume();
+  try {
+    assert.throws(
+      () =>
+        new TenantResolver({
+          tokens: { t1: "/etc" },
+          volumeRoot: v.root,
+        }),
+      ConfigError,
+    );
+  } finally {
+    await v.cleanup();
+  }
+});
+
+test("TenantResolver — refuses empty volume root", () => {
+  assert.throws(() => new TenantResolver({ tokens: { t1: "/x" }, volumeRoot: "" }), ConfigError);
+});
+
+test("TenantResolver — refuses zero tenants", async () => {
+  const v = await makeVolume();
+  try {
+    assert.throws(() => new TenantResolver({ tokens: {}, volumeRoot: v.root }), ConfigError);
+  } finally {
+    await v.cleanup();
+  }
+});
+
+test("TenantResolver — accepts tenant under volume + resolves bearer", async () => {
+  const v = await makeVolume();
+  try {
+    const r = new TenantResolver({ tokens: { t1: v.tenantPath }, volumeRoot: v.root });
+    const ok = r.resolveBearer("Bearer t1");
+    assert.ok(ok);
+    assert.equal(ok!.config.workspacePath, v.tenantPath);
+    assert.equal(r.resolveBearer(undefined), null);
+    assert.equal(r.resolveBearer("Bearer wrong"), null);
+    assert.equal(r.resolveBearer("Basic abc"), null);
+  } finally {
+    await v.cleanup();
+  }
+});
+
+test("processBundle — happy path calls learnFromTrace and returns synthesis names", async () => {
+  const v = await makeVolume();
+  try {
+    const bundle = await loadBundle();
+    let received = null as null | { intent: string; reqs: number };
+    const result = await processBundle(
+      bundle,
+      { id: "acme", workspacePath: v.tenantPath },
+      {
+        agentFor: () => ({
+          async learnFromTrace(trace) {
+            received = { intent: trace.intent, reqs: trace.requests.length };
+            return { workflow: "onboard_enterprise", wrappers: ["create_customer"], commit: "abc1234" };
+          },
+        }),
+      },
+    );
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.workflow, "onboard_enterprise");
+      assert.deepStrictEqual(result.wrappers, ["create_customer"]);
+      assert.equal(result.commit, "abc1234");
+      assert.equal(result.tenant, "acme");
+      assert.match(result.traceId, /^[0-9a-f-]{36}$/);
+    }
+    assert.ok(received);
+    assert.equal(received!.reqs, 1);
+    assert.match(received!.intent, /Onboard a new enterprise customer/);
+    assert.match(received!.intent, /\[narration:/);
+  } finally {
+    await v.cleanup();
+  }
+});
+
+test("processBundle — wraps synthesis exception as 500", async () => {
+  const v = await makeVolume();
+  try {
+    const bundle = await loadBundle();
+    const result = await processBundle(
+      bundle,
+      { id: "acme", workspacePath: v.tenantPath },
+      {
+        agentFor: () => ({
+          async learnFromTrace() {
+            throw new Error("boom");
+          },
+        }),
+      },
+    );
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 500);
+      assert.equal(result.error, "synthesis_failed");
+      assert.match(result.detail, /boom/);
+    }
+  } finally {
+    await v.cleanup();
+  }
+});
+
+test("createApp — POST /v1/bundles unauthorized without bearer", async () => {
+  const v = await makeVolume();
+  try {
+    const resolver = new TenantResolver({ tokens: { t1: v.tenantPath }, volumeRoot: v.root });
+    const app = createApp({
+      resolver,
+      logRequests: false,
+      agentFor: () => ({ async learnFromTrace() { throw new Error("should not run"); } }),
+    });
+    const res = await app.request("/v1/bundles", {
+      method: "POST",
+      body: "{}",
+      headers: { "Content-Type": "application/json" },
+    });
+    assert.equal(res.status, 401);
+    const body = await res.json() as { error: string };
+    assert.equal(body.error, "unauthorized");
+  } finally {
+    await v.cleanup();
+  }
+});
+
+test("createApp — POST /v1/bundles 400 on schema fail", async () => {
+  const v = await makeVolume();
+  try {
+    const resolver = new TenantResolver({ tokens: { t1: v.tenantPath }, volumeRoot: v.root });
+    const app = createApp({
+      resolver,
+      logRequests: false,
+      agentFor: () => ({ async learnFromTrace() { throw new Error("should not run"); } }),
+    });
+    const res = await app.request("/v1/bundles", {
+      method: "POST",
+      body: JSON.stringify({ schemaVersion: "2" }),
+      headers: { "Content-Type": "application/json", Authorization: "Bearer t1" },
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json() as { error: string };
+    assert.equal(body.error, "invalid_bundle");
+  } finally {
+    await v.cleanup();
+  }
+});
+
+test("createApp — POST /v1/bundles 200 happy path", async () => {
+  const v = await makeVolume();
+  try {
+    const bundle = await loadBundle();
+    const resolver = new TenantResolver({ tokens: { tok123: v.tenantPath }, volumeRoot: v.root });
+    const app = createApp({
+      resolver,
+      logRequests: false,
+      agentFor: () => ({
+        async learnFromTrace() {
+          return { workflow: "wf_a", wrappers: ["w_x"], commit: "deadbeef" };
+        },
+      }),
+    });
+    const res = await app.request("/v1/bundles", {
+      method: "POST",
+      body: JSON.stringify(bundle),
+      headers: { "Content-Type": "application/json", Authorization: "Bearer tok123" },
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json() as { accepted: boolean; workflow: string; wrappers: string[]; commit: string; tenant: string; traceId: string };
+    assert.equal(body.accepted, true);
+    assert.equal(body.workflow, "wf_a");
+    assert.deepStrictEqual(body.wrappers, ["w_x"]);
+    assert.equal(body.commit, "deadbeef");
+    assert.equal(body.tenant, path.basename(v.tenantPath));
+  } finally {
+    await v.cleanup();
+  }
+});
+
+test("createApp — GET /healthz reports tenant count + volume", async () => {
+  const v = await makeVolume();
+  try {
+    const resolver = new TenantResolver({ tokens: { t1: v.tenantPath }, volumeRoot: v.root });
+    const app = createApp({ resolver, logRequests: false, agentFor: () => ({ async learnFromTrace() { return { workflow: "", wrappers: [], commit: "" }; } }) });
+    const res = await app.request("/healthz");
+    assert.equal(res.status, 200);
+    const body = await res.json() as { status: string; tenants: number; volumeRoot: string };
+    assert.equal(body.status, "ok");
+    assert.equal(body.tenants, 1);
+    assert.equal(body.volumeRoot, v.root);
+  } finally {
+    await v.cleanup();
+  }
+});


### PR DESCRIPTION
Receives bundles from the browser extension, validates them, and runs `SpecialistAgent.learnFromTrace` so each accepted recording commits new/updated skills to the tenant's git workspace. Same code path the CLI's `learn --bundle=...` already uses, just wrapped in HTTP + multi-tenant auth + a strict Railway volume guard.

```
extension → POST /v1/bundles → BundleSchema.parse → importHar →
  agent.learnFromTrace → git commit on tenant branch → 200 { workflow, wrappers, commit, traceId }
```

## Summary

- **`src/server/auth.ts`** — bearer→tenant resolver. **Refuses to start if `RAILWAY_VOLUME_MOUNT_PATH` is unset, or if any tenant path resolves outside that mount.** No silent demotion to ephemeral storage. `BUNDLE_TOKENS` accepts CSV (`tok-acme:/data/tenants/acme,...`) or JSON.
- **`src/server/handler.ts`** — pure bundle→synthesis function (no HTTP). Generates a UUID `traceId`, prepends narration to the intent, wraps synthesis exceptions as `500 synthesis_failed`.
- **`src/server/app.ts`** — Hono with CORS + 50 MiB body cap. Every error path returns JSON `{error, detail}` so the extension's existing parser works.
- **`src/server/main.ts`** — env-driven entry; exits `2` on misconfiguration so Railway flags the deploy.
- **`Dockerfile`** — `node:20-slim`, git installed (tenant repos are git), non-root user, `/healthz` HEALTHCHECK.
- **`docs/SERVER.md`** — Railway 5-step deploy guide + env contract.
- **14 new tests** (45 total): token parsing, volume guard, bearer auth, schema rejection, 200 happy path, 500 wrap, `/healthz`. Stubs `learnFromTrace` so CI never hits Anthropic.

## Why Hono

Two routes today (POST + healthz), grows to 4–6 (status, list, webhook). Routing, body-size limits, error normalization, and CORS are one-liners; with raw `node:http` they're a manual stream loop. Single ~14kb dep with zero transitive bloat.

## Endpoints

- `POST /v1/bundles` — synchronous (30–90s for one Claude call). Returns `{accepted, traceId, workflow, wrappers, commit, tenant}`. Errors: 400 `invalid_bundle`, 401 `unauthorized`, 413 `bundle_too_large`, 500 `synthesis_failed`.
- `GET /healthz` — reports tenant count + volume root.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 45/45 passing
- [x] Volume guard exits 2 on misconfigured paths (covered by tests)
- [x] Bearer auth: missing/wrong/non-Bearer headers all return 401
- [ ] Railway deploy smoke test — set `ANTHROPIC_API_KEY` + `BUNDLE_TOKENS` + mount `/data`; POST the shared `test/fixtures/bundle-example.json`; verify a commit lands on the tenant repo
- [ ] Wire an extension to the Railway URL + bearer token; record a real workflow end-to-end

## Known v1 limits (called out in `docs/SERVER.md`)

- Synchronous synthesis — POST blocks for the full Claude call. v1.1 = `202 Accepted` + `GET /v1/traces/:id`.
- Single platform Anthropic key (no per-tenant keys yet).
- No quotas / rate limiting.

https://claude.ai/code/session_01AieyEWpygA38wNARESAv6x

---
_Generated by [Claude Code](https://claude.ai/code/session_01AieyEWpygA38wNARESAv6x)_